### PR TITLE
fix(release): drop v prefix from version in plugin manifests

### DIFF
--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -3,7 +3,7 @@
   "plugin": {
     "name": "Rikugan",
     "entryPoint": "rikugan_plugin.py",
-    "version": "v1.1",
+    "version": "1.1",
     "description": "Agentic LLM reverse-engineering companion embedded directly in IDA Pro. Supports multi-provider LLMs (Anthropic, OpenAI, Google Gemini, Ollama), 60+ native tools, exploration mode with parallel subagents, natural-language binary patching, skills, and MCP server integration.",
     "license": "MIT",
     "categories": [

--- a/plugin.json
+++ b/plugin.json
@@ -34,6 +34,6 @@
     "Windows": "Clone/symlink this repository into %APPDATA%/Binary Ninja/plugins/rikugan"
   },
   "projectUrl": "https://github.com/buzzer-re/rikugan",
-  "version": "v1.1",
+  "version": "1.1",
   "minimumbinaryninjaversion": 3164
 }


### PR DESCRIPTION
The release workflow strips the v from the git tag before comparing against plugin.json, so the version field must be bare (1.1 not v1.1).