### PR TITLE
fix(ui): detect host Qt version to prevent Qt5/Qt6 dual-load crash on…

### DIFF
--- a/rikugan/ida/ui/panel.py
+++ b/rikugan/ida/ui/panel.py
@@ -6,7 +6,7 @@ import importlib
 from typing import Any
 
 from rikugan.ui.panel_core import RikuganPanelCore
-from rikugan.ui.qt_compat import QVBoxLayout, QWidget
+from rikugan.ui.qt_compat import QT_BINDING, QVBoxLayout, QWidget
 
 from .actions import RikuganUIHooks
 from .session_controller import IdaSessionController
@@ -24,10 +24,13 @@ class RikuganPanel(idaapi.PluginForm):
         self._core: RikuganPanelCore | None = None
 
     def OnCreate(self, form: Any) -> None:
-        try:
+        if QT_BINDING == "PyQt5":
             self._form_widget = self.FormToPyQtWidget(form)
-        except Exception:
-            self._form_widget = self.FormToPySideWidget(form)
+        else:
+            try:
+                self._form_widget = self.FormToPySideWidget(form)
+            except Exception:
+                self._form_widget = self.FormToPyQtWidget(form)
 
         self._root = QWidget()
         form_layout = QVBoxLayout(self._form_widget)

--- a/rikugan/ui/qt_compat.py
+++ b/rikugan/ui/qt_compat.py
@@ -1,53 +1,141 @@
 """Qt compatibility layer for Rikugan.
 
-IDA 9+ ships PySide6 exclusively (its ``PyQt5`` module is a thin shim over
-PySide6, not a separate binding).  We import from PySide6 directly to
-minimize Shiboken type-wrapper initialization and reduce the crash surface
-on Python 3.14.
+IDA 9.x 64-bit and Binary Ninja ship PySide6 (Qt6).  IDA 9.1 32-bit on
+Windows still uses Qt5 — its process has Qt5Core.dll loaded.  Importing
+PySide6 in that environment loads Qt6 DLLs alongside Qt5, which triggers a
+``FAST_FAIL_FATAL_APP_EXIT`` crash inside ``QWidgetPrivate::QWidgetPrivate``
+(Qt6 widget constructor detects it is not running in a Qt6 QApplication).
+
+Detection order:
+1. Check ``sys.modules`` for an already-loaded binding (fast, cross-platform).
+2. On Windows, check if ``Qt5Core.dll`` is loaded in the process — if so, the
+   host is Qt5-based and we must avoid loading PySide6.
+3. Default: try PySide6, fall back to PyQt5.
 """
 
 from __future__ import annotations
 
-from PySide6.QtCore import QObject, Qt, QTimer, Signal  # noqa: F401
-from PySide6.QtGui import (  # noqa: F401
-    QColor,
-    QFont,
-    QSyntaxHighlighter,
-    QTextCharFormat,
-)
-from PySide6.QtWidgets import (  # noqa: F401
-    QApplication,
-    QCheckBox,
-    QComboBox,
-    QDialog,
-    QDialogButtonBox,
-    QDoubleSpinBox,
-    QFileDialog,
-    QFormLayout,
-    QFrame,
-    QGroupBox,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QListWidget,
-    QListWidgetItem,
-    QMenu,
-    QMessageBox,
-    QPlainTextEdit,
-    QPushButton,
-    QScrollArea,
-    QSizePolicy,
-    QSpinBox,
-    QSplitter,
-    QTabBar,
-    QTabWidget,
-    QToolButton,
-    QVBoxLayout,
-    QWidget,
-)
+import sys
 
-QT_BINDING = "PySide6"
+
+def _detect_binding() -> str:
+    """Return ``"PySide6"`` or ``"PyQt5"`` based on the host environment."""
+
+    # Fast path: a binding is already imported by the host.
+    has_pyside6 = any(k.startswith("PySide6.") for k in sys.modules)
+    has_pyqt5 = any(k.startswith("PyQt5.") for k in sys.modules)
+
+    if has_pyside6 and not has_pyqt5:
+        return "PySide6"
+    if has_pyqt5 and not has_pyside6:
+        return "PyQt5"
+
+    # On Windows, check whether Qt5 DLLs are already loaded by the host
+    # process *before* importing anything that would pull in Qt6.
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+            kernel32.GetModuleHandleW.restype = ctypes.c_void_p
+            if kernel32.GetModuleHandleW("Qt5Core.dll"):
+                return "PyQt5"
+        except Exception:
+            pass
+
+    # Default: prefer PySide6, fall back to PyQt5.
+    try:
+        import PySide6  # noqa: F401
+
+        return "PySide6"
+    except ImportError:
+        return "PyQt5"
+
+
+QT_BINDING: str = _detect_binding()
+
+# ---------------------------------------------------------------------------
+# Import the chosen binding, aliasing PyQt5 names to match PySide6 API.
+# ---------------------------------------------------------------------------
+
+if QT_BINDING == "PySide6":
+    from PySide6.QtCore import QObject, Qt, QTimer, Signal
+    from PySide6.QtGui import (
+        QColor,
+        QFont,
+        QSyntaxHighlighter,
+        QTextCharFormat,
+    )
+    from PySide6.QtWidgets import (
+        QApplication,
+        QCheckBox,
+        QComboBox,
+        QDialog,
+        QDialogButtonBox,
+        QDoubleSpinBox,
+        QFileDialog,
+        QFormLayout,
+        QFrame,
+        QGroupBox,
+        QHBoxLayout,
+        QLabel,
+        QLineEdit,
+        QListWidget,
+        QListWidgetItem,
+        QMenu,
+        QMessageBox,
+        QPlainTextEdit,
+        QPushButton,
+        QScrollArea,
+        QSizePolicy,
+        QSpinBox,
+        QSplitter,
+        QTabBar,
+        QTabWidget,
+        QToolButton,
+        QVBoxLayout,
+        QWidget,
+    )
+else:
+    from PyQt5.QtCore import QObject, Qt, QTimer  # noqa: F401
+    from PyQt5.QtCore import pyqtSignal as Signal  # noqa: F401
+    from PyQt5.QtGui import (  # noqa: F401
+        QColor,
+        QFont,
+        QSyntaxHighlighter,
+        QTextCharFormat,
+    )
+    from PyQt5.QtWidgets import (  # noqa: F401
+        QApplication,
+        QCheckBox,
+        QComboBox,
+        QDialog,
+        QDialogButtonBox,
+        QDoubleSpinBox,
+        QFileDialog,
+        QFormLayout,
+        QFrame,
+        QGroupBox,
+        QHBoxLayout,
+        QLabel,
+        QLineEdit,
+        QListWidget,
+        QListWidgetItem,
+        QMenu,
+        QMessageBox,
+        QPlainTextEdit,
+        QPushButton,
+        QScrollArea,
+        QSizePolicy,
+        QSpinBox,
+        QSplitter,
+        QTabBar,
+        QTabWidget,
+        QToolButton,
+        QVBoxLayout,
+        QWidget,
+    )
 
 
 def is_pyside6() -> bool:
-    return True
+    return QT_BINDING == "PySide6"


### PR DESCRIPTION
… IDA 9.1 32-bit

IDA 9.1 32-bit on Windows uses Qt5 for its UI. Unconditionally importing PySide6 loaded Qt6 DLLs alongside Qt5, triggering FAST_FAIL_FATAL_APP_EXIT in QWidgetPrivate. Now qt_compat.py detects the host's Qt binding at runtime (sys.modules check + Win32 GetModuleHandleW) and falls back to PyQt5 when the host is Qt5-based.

Related to #17