### PR TITLE
fix(ui): remove Qt shim-dependent API usage

### DIFF
--- a/rikugan/ui/agent_tree.py
+++ b/rikugan/ui/agent_tree.py
@@ -17,6 +17,7 @@ from .qt_compat import (
     QVBoxLayout,
     QWidget,
     Signal,
+    qt_flags,
 )
 
 _STATUS_COLORS: dict[str, str] = {
@@ -209,7 +210,7 @@ class AgentTreeWidget(QWidget):
         else:
             item = QTreeWidgetItem(self._tree)
             item.setData(0, Qt.ItemDataRole.UserRole, info.agent_id)
-            item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+            item.setFlags(qt_flags(Qt.ItemFlag.ItemIsEnabled, Qt.ItemFlag.ItemIsSelectable))
             self._items[info.agent_id] = item
 
         item.setText(0, info.name)

--- a/rikugan/ui/bulk_renamer.py
+++ b/rikugan/ui/bulk_renamer.py
@@ -23,6 +23,7 @@ from .qt_compat import (
     QVBoxLayout,
     QWidget,
     Signal,
+    qt_flags,
 )
 
 _BTN_STYLE = (
@@ -410,35 +411,35 @@ class BulkRenamerWidget(QWidget):
             check_item.setCheckState(
                 Qt.CheckState.Checked if (is_auto and not entry.is_import) else Qt.CheckState.Unchecked
             )
-            check_item.setFlags(Qt.ItemFlag.ItemIsUserCheckable | Qt.ItemFlag.ItemIsEnabled)
+            check_item.setFlags(qt_flags(Qt.ItemFlag.ItemIsUserCheckable, Qt.ItemFlag.ItemIsEnabled))
             self._table.setItem(row, _COL_CHECK, check_item)
 
             # Address (numeric sort, store address in UserRole for lookup)
             addr_item = _NumericTableItem(f"0x{entry.address:X}", entry.address)
-            addr_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+            addr_item.setFlags(qt_flags(Qt.ItemFlag.ItemIsEnabled, Qt.ItemFlag.ItemIsSelectable))
             addr_item.setData(Qt.ItemDataRole.UserRole, entry.address)
             addr_item.setToolTip(f"0x{entry.address:016X}")
             self._table.setItem(row, _COL_ADDR, addr_item)
 
             # Current name
             name_item = QTableWidgetItem(entry.name)
-            name_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+            name_item.setFlags(qt_flags(Qt.ItemFlag.ItemIsEnabled, Qt.ItemFlag.ItemIsSelectable))
             self._table.setItem(row, _COL_NAME, name_item)
 
             # Length (numeric sort)
             length_item = _NumericTableItem(str(ic) if ic else "0", ic)
-            length_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
-            length_item.setTextAlignment(Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter)
+            length_item.setFlags(qt_flags(Qt.ItemFlag.ItemIsEnabled, Qt.ItemFlag.ItemIsSelectable))
+            length_item.setTextAlignment(qt_flags(Qt.AlignmentFlag.AlignRight, Qt.AlignmentFlag.AlignVCenter))
             self._table.setItem(row, _COL_LENGTH, length_item)
 
             # New name (initially empty)
             new_item = QTableWidgetItem("")
-            new_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+            new_item.setFlags(qt_flags(Qt.ItemFlag.ItemIsEnabled, Qt.ItemFlag.ItemIsSelectable))
             self._table.setItem(row, _COL_NEWNAME, new_item)
 
             # Status
             status_item = QTableWidgetItem("")
-            status_item.setFlags(Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable)
+            status_item.setFlags(qt_flags(Qt.ItemFlag.ItemIsEnabled, Qt.ItemFlag.ItemIsSelectable))
             self._table.setItem(row, _COL_STATUS, status_item)
 
     def _finish_load(self) -> None:

--- a/rikugan/ui/bulk_renamer.py
+++ b/rikugan/ui/bulk_renamer.py
@@ -312,6 +312,7 @@ class BulkRenamerWidget(QWidget):
         # Internal state
         self._entries: list[FunctionEntry] = []
         self._addr_to_entry: dict[int, int] = {}  # address -> index in _entries
+        self._addr_to_row: dict[int, int] = {}  # address -> current table row when unsorted/load order row
         self._paused = False
 
     def _reposition_header_check(self, _idx: int = 0, _old: int = 0, _new: int = 0) -> None:
@@ -351,6 +352,7 @@ class BulkRenamerWidget(QWidget):
         self._table.setRowCount(0)
         self._entries.clear()
         self._addr_to_entry.clear()
+        self._addr_to_row.clear()
 
         self._table.setRowCount(len(functions))
 
@@ -402,6 +404,7 @@ class BulkRenamerWidget(QWidget):
             )
             self._entries.append(entry)
             self._addr_to_entry[entry.address] = row
+            self._addr_to_row[entry.address] = row
 
             ic = entry.instruction_count
 
@@ -475,9 +478,13 @@ class BulkRenamerWidget(QWidget):
 
     def _find_row_for_address(self, address: int) -> int | None:
         """Find the current visual row for a given address (sort-safe)."""
+        cached_row = self._addr_to_row.get(address)
+        if cached_row is not None:
+            return cached_row
         for row in range(self._table.rowCount()):
             addr_item = self._table.item(row, _COL_ADDR)
             if addr_item is not None and addr_item.data(Qt.ItemDataRole.UserRole) == address:
+                self._addr_to_row[address] = row
                 return row
         return None
 

--- a/rikugan/ui/markdown.py
+++ b/rikugan/ui/markdown.py
@@ -29,6 +29,11 @@ _LINK_COLOR = "#569cd6"
 _HR_COLOR = "#3c3c3c"
 _H_COLOR = "#569cd6"
 
+_MARKDOWN_HINT_RE = re.compile(
+    r"(^#{1,4}\s)|(^\s*[-*]\s+)|(^\s*\d+[.)]\s+)|```|`[^`]+`|\*\*|__|(?<!\w)\*(.+?)\*(?!\w)|(?<!\w)_(.+?)_(?!\w)|\[[^\]]+\]\([^)]+\)|^[-*_]{3,}\s*$",
+    re.MULTILINE,
+)
+
 _INLINE_CODE_STYLE = (
     f"background-color:{_CODE_BG}; color:{_CODE_FG}; "
     f"padding:1px 4px; border-radius:3px; font-family:monospace; font-size:12px;"
@@ -42,10 +47,18 @@ _BLOCK_CODE_STYLE = (
 )
 
 
+def _has_markdown_syntax(text: str) -> bool:
+    """Return True when the input likely needs markdown processing."""
+    return bool(text and _MARKDOWN_HINT_RE.search(text))
+
+
 def md_to_html(text: str) -> str:
     """Convert a Markdown string to Qt-compatible HTML."""
     if not text:
         return ""
+    if not _has_markdown_syntax(text):
+        escaped = html.escape(text).replace("\n", "<br>")
+        return re.sub(r"(<br>\s*){3,}", "<br><br>", escaped)
 
     # Phase 1: extract fenced code blocks to protect them from inline processing
     blocks: list[str] = []

--- a/rikugan/ui/message_widgets.py
+++ b/rikugan/ui/message_widgets.py
@@ -18,6 +18,7 @@ from .qt_compat import (
     QToolButton,
     QVBoxLayout,
     QWidget,
+    qt_flags,
 )
 
 _THINKING_PHRASES = [
@@ -115,7 +116,10 @@ class UserMessageWidget(QFrame):
         self._content = QLabel(text)
         self._content.setWordWrap(True)
         self._content.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+            qt_flags(
+                Qt.TextInteractionFlag.TextSelectableByMouse,
+                Qt.TextInteractionFlag.TextSelectableByKeyboard,
+            )
         )
         self._content.setStyleSheet("color: #d4d4d4; font-size: 13px;")
         self._content.setMinimumWidth(0)
@@ -196,7 +200,10 @@ class _ThinkingBlock(QFrame):
         self._content.setWordWrap(True)
         self._content.setTextFormat(Qt.TextFormat.RichText)
         self._content.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+            qt_flags(
+                Qt.TextInteractionFlag.TextSelectableByMouse,
+                Qt.TextInteractionFlag.TextSelectableByKeyboard,
+            )
         )
         self._content.setStyleSheet("color: #606078; font-size: 12px;")
         self._content.hide()
@@ -248,9 +255,11 @@ class AssistantMessageWidget(QFrame):
         self._content.setWordWrap(True)
         self._content.setTextFormat(Qt.TextFormat.RichText)
         self._content.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse
-            | Qt.TextInteractionFlag.TextSelectableByKeyboard
-            | Qt.TextInteractionFlag.LinksAccessibleByMouse
+            qt_flags(
+                Qt.TextInteractionFlag.TextSelectableByMouse,
+                Qt.TextInteractionFlag.TextSelectableByKeyboard,
+                Qt.TextInteractionFlag.LinksAccessibleByMouse,
+            )
         )
         self._content.setOpenExternalLinks(True)
         self._content.setStyleSheet("color: #d4d4d4; font-size: 13px;")
@@ -364,7 +373,10 @@ class QueuedMessageWidget(QFrame):
         self._content = QLabel(text)
         self._content.setWordWrap(True)
         self._content.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+            qt_flags(
+                Qt.TextInteractionFlag.TextSelectableByMouse,
+                Qt.TextInteractionFlag.TextSelectableByKeyboard,
+            )
         )
         self._content.setStyleSheet("color: #d4d4d4; font-size: 13px;")
         content_layout.addWidget(self._content)
@@ -399,7 +411,10 @@ class UserQuestionWidget(QFrame):
         self._q_label = QLabel(question)
         self._q_label.setWordWrap(True)
         self._q_label.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+            qt_flags(
+                Qt.TextInteractionFlag.TextSelectableByMouse,
+                Qt.TextInteractionFlag.TextSelectableByKeyboard,
+            )
         )
         self._q_label.setStyleSheet("color: #d4d4d4; font-size: 13px;")
         layout.addWidget(self._q_label)
@@ -627,7 +642,10 @@ class ErrorMessageWidget(QFrame):
         self._content = QLabel(error_text)
         self._content.setWordWrap(True)
         self._content.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+            qt_flags(
+                Qt.TextInteractionFlag.TextSelectableByMouse,
+                Qt.TextInteractionFlag.TextSelectableByKeyboard,
+            )
         )
         self._content.setStyleSheet("color: #f44747; font-size: 12px;")
         self._content.setMinimumWidth(0)

--- a/rikugan/ui/panel_core.py
+++ b/rikugan/ui/panel_core.py
@@ -37,6 +37,8 @@ from .qt_compat import (
     QToolButton,
     QVBoxLayout,
     QWidget,
+    qt_flags,
+    qt_run,
 )
 from .styles import DARK_THEME
 from .tool_widgets import _SharedSpinnerTimer
@@ -202,7 +204,7 @@ class _AddButtonTabBar(QTabBar):
         menu = QMenu(self)
         export_action = menu.addAction("Export Chat")
         fork_action = menu.addAction("Fork Session")
-        action = menu.exec_(self.mapToGlobal(pos))
+        action = qt_run(menu, self.mapToGlobal(pos))
         if action == export_action and self._export_tab_callback is not None:
             self._export_tab_callback(index)
         elif action == fork_action and self._fork_tab_callback is not None:
@@ -290,13 +292,16 @@ class RikuganPanelCore(QWidget):
             pw_edit.setPlaceholderText("Password")
             layout.addWidget(pw_edit)
             buttons = QDialogButtonBox(
-                QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
+                qt_flags(
+                    QDialogButtonBox.StandardButton.Ok,
+                    QDialogButtonBox.StandardButton.Cancel,
+                ),
             )
             buttons.accepted.connect(dlg.accept)
             buttons.rejected.connect(dlg.reject)
             layout.addWidget(buttons)
 
-            if dlg.exec_() != QDialog.DialogCode.Accepted:
+            if qt_run(dlg) != QDialog.DialogCode.Accepted:
                 break  # user cancelled — keys stay empty
             if self._config.decrypt_stored_keys(pw_edit.text()):
                 log_debug("API keys decrypted successfully")
@@ -635,11 +640,16 @@ class RikuganPanelCore(QWidget):
             cb = QCheckBox(f"Include subagent logs ({len(session.subagent_logs)} subagent runs)")
             cb.setChecked(True)
             layout.addWidget(cb)
-            buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+            buttons = QDialogButtonBox(
+                qt_flags(
+                    QDialogButtonBox.StandardButton.Ok,
+                    QDialogButtonBox.StandardButton.Cancel,
+                )
+            )
             buttons.accepted.connect(dlg.accept)
             buttons.rejected.connect(dlg.reject)
             layout.addWidget(buttons)
-            if not dlg.exec():
+            if not qt_run(dlg):
                 return
             include_subagents = cb.isChecked()
 
@@ -886,7 +896,7 @@ class RikuganPanelCore(QWidget):
                 registry=self._ctrl.provider_registry,
                 tool_registry=self._ctrl.tool_registry,
             )
-            result = dlg.exec_()
+            result = qt_run(dlg)
             if result:
                 self._config.save(password=dlg.encryption_password)
                 self._ctrl.update_settings()
@@ -918,7 +928,7 @@ class RikuganPanelCore(QWidget):
         )
         no_btn = dlg.addButton("No", QMessageBox.ButtonRole.RejectRole)
         dlg.setDefaultButton(no_btn)
-        dlg.exec_()
+        qt_run(dlg)
         clicked = dlg.clickedButton()
         if clicked is clear_btn:
             return "clear"

--- a/rikugan/ui/panel_core.py
+++ b/rikugan/ui/panel_core.py
@@ -262,6 +262,7 @@ class RikuganPanelCore(QWidget):
 
         # Tab-to-ChatView mapping
         self._chat_views: dict[str, ChatView] = {}
+        self._pending_restore_messages: dict[str, list] = {}
         self._context_bar: ContextBar | None = None
         self._mutation_panel: MutationLogPanel | None = None
         self._skills_refresh_timer: QTimer | None = None
@@ -734,6 +735,7 @@ class RikuganPanelCore(QWidget):
         if tab_id is None:
             return
         self._ctrl.switch_tab(tab_id)
+        self._restore_messages_if_needed(tab_id)
         self._update_token_display()
 
     def _tab_id_at_index(self, index: int) -> str | None:
@@ -753,6 +755,15 @@ class RikuganPanelCore(QWidget):
     def _active_chat_view(self) -> ChatView | None:
         """Return the ChatView for the currently active tab."""
         return self._chat_views.get(self._ctrl.active_tab_id)
+
+    def _restore_messages_if_needed(self, tab_id: str) -> None:
+        """Replay deferred restored messages for a tab the first time it is shown."""
+        messages = self._pending_restore_messages.pop(tab_id, None)
+        if not messages:
+            return
+        chat_view = self._chat_views.get(tab_id)
+        if chat_view is not None:
+            chat_view.restore_from_messages(messages)
 
     def _update_token_display(self, token_count: int | None = None) -> None:
         """Update the context bar token display with context window percentage."""
@@ -841,6 +852,7 @@ class RikuganPanelCore(QWidget):
             if w:
                 w.deleteLater()
         self._chat_views.clear()
+        self._pending_restore_messages.clear()
         # Create default tab and try to restore saved sessions
         self._create_tab(self._ctrl.active_tab_id, "New Chat")
         self._try_restore_session()
@@ -1078,8 +1090,8 @@ class RikuganPanelCore(QWidget):
 
             for tab_id, session in restored:
                 label = self._ctrl.tab_label(tab_id)
-                cv = self._create_tab(tab_id, label)
-                cv.restore_from_messages(session.messages)
+                self._pending_restore_messages[tab_id] = session.messages
+                self._create_tab(tab_id, label)
 
             # Activate the last (most recent) tab
             if restored:
@@ -1090,6 +1102,7 @@ class RikuganPanelCore(QWidget):
                         if self._tab_widget.widget(i) is last_cv:
                             self._tab_widget.setCurrentIndex(i)
                             break
+                    self._restore_messages_if_needed(last_tab_id)
                 self._update_token_display()
         else:
             # No saved sessions — try legacy single-session restore

--- a/rikugan/ui/qt_compat.py
+++ b/rikugan/ui/qt_compat.py
@@ -159,5 +159,36 @@ else:
     )
 
 
+def qt_flags(*flags: object) -> object:
+    """Combine Qt enum/flag values without relying on PyQt5 shim bitwise behavior."""
+    if not flags:
+        return 0
+
+    value = 0
+    flag_type = None
+    for flag in flags:
+        if flag_type is None:
+            flag_type = type(flag)
+        value |= int(getattr(flag, "value", flag))
+
+    if flag_type is not None:
+        try:
+            return flag_type(value)
+        except Exception:
+            pass
+    return value
+
+
+def qt_run(obj: object, *args, **kwargs) -> object:
+    """Call Qt6-style run API with Qt5 fallback where needed."""
+    run = getattr(obj, "exec", None)
+    if callable(run):
+        return run(*args, **kwargs)
+    run_legacy = getattr(obj, "exec_", None)
+    if callable(run_legacy):
+        return run_legacy(*args, **kwargs)
+    raise AttributeError(f"{type(obj).__name__} has no exec/exec_ method")
+
+
 def is_pyside6() -> bool:
     return QT_BINDING == "PySide6"

--- a/rikugan/ui/qt_compat.py
+++ b/rikugan/ui/qt_compat.py
@@ -16,6 +16,7 @@ Detection order:
 from __future__ import annotations
 
 import sys
+from typing import Any, cast
 
 
 def _detect_binding() -> str:
@@ -160,23 +161,24 @@ else:
 
 
 def qt_flags(*flags: object) -> object:
-    """Combine Qt enum/flag values without relying on PyQt5 shim bitwise behavior."""
+    """Combine same-family Qt enum/flag values without relying on PyQt5 shim bitwise behavior."""
     if not flags:
         return 0
 
     value = 0
-    flag_type = None
+    flag_type: type[Any] | None = None
     for flag in flags:
+        current_type = type(flag)
         if flag_type is None:
-            flag_type = type(flag)
-        value |= int(getattr(flag, "value", flag))
+            flag_type = current_type
+        elif current_type is not flag_type:
+            raise TypeError(f"qt_flags() received mixed flag types: {flag_type.__name__} and {current_type.__name__}")
+        flag_value = getattr(flag, "value", flag)
+        value |= int(cast(Any, flag_value))
 
-    if flag_type is not None:
-        try:
-            return flag_type(value)
-        except Exception:
-            pass
-    return value
+    if flag_type is None:
+        return value
+    return cast(Any, flag_type)(value)
 
 
 def qt_run(obj: object, *args, **kwargs) -> object:

--- a/rikugan/ui/settings_dialog.py
+++ b/rikugan/ui/settings_dialog.py
@@ -752,16 +752,19 @@ class SettingsDialog(QDialog):
             pw_confirm.setPlaceholderText("Confirm password")
             layout.addWidget(pw_confirm)
 
-        from .qt_compat import QDialogButtonBox
+        from .qt_compat import QDialogButtonBox, qt_flags, qt_run
 
         buttons = QDialogButtonBox(
-            QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
+            qt_flags(
+                QDialogButtonBox.StandardButton.Ok,
+                QDialogButtonBox.StandardButton.Cancel,
+            ),
         )
         buttons.accepted.connect(dlg.accept)
         buttons.rejected.connect(dlg.reject)
         layout.addWidget(buttons)
 
-        if dlg.exec_() != QDialog.DialogCode.Accepted:
+        if qt_run(dlg) != QDialog.DialogCode.Accepted:
             return ""
 
         password = pw_edit.text()

--- a/rikugan/ui/tool_widgets.py
+++ b/rikugan/ui/tool_widgets.py
@@ -20,6 +20,7 @@ from .qt_compat import (
     QToolButton,
     QVBoxLayout,
     QWidget,
+    qt_flags,
 )
 
 _MAX_ARGS_DISPLAY = 2000
@@ -511,7 +512,10 @@ class ToolCallWidget(QFrame):
         self._args_label.setObjectName("tool_content")
         self._args_label.setWordWrap(True)
         self._args_label.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+            qt_flags(
+                Qt.TextInteractionFlag.TextSelectableByMouse,
+                Qt.TextInteractionFlag.TextSelectableByKeyboard,
+            )
         )
         self._detail_layout.addWidget(self._args_label)
 
@@ -524,7 +528,10 @@ class ToolCallWidget(QFrame):
         self._result_label.setObjectName("tool_content")
         self._result_label.setWordWrap(True)
         self._result_label.setTextInteractionFlags(
-            Qt.TextInteractionFlag.TextSelectableByMouse | Qt.TextInteractionFlag.TextSelectableByKeyboard
+            qt_flags(
+                Qt.TextInteractionFlag.TextSelectableByMouse,
+                Qt.TextInteractionFlag.TextSelectableByKeyboard,
+            )
         )
         self._result_label.setVisible(False)
         self._detail_layout.addWidget(self._result_label)

--- a/tests/agent/test_session_controller.py
+++ b/tests/agent/test_session_controller.py
@@ -12,6 +12,25 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from tests.mocks.ida_mock import install_ida_mocks
 install_ida_mocks()
 
+# Some UI tests stub modules in sys.modules; ensure this test gets real ones.
+for _mod_name in [
+    "rikugan.core.types",
+    "rikugan.core.config",
+    "rikugan.core.logging",
+    "rikugan.agent.turn",
+    "rikugan.agent.mutation",
+    "rikugan.providers.auth_cache",
+    "rikugan.providers.anthropic_provider",
+    "rikugan.providers.ollama_provider",
+    "rikugan.providers.registry",
+    "rikugan.ui.chat_view",
+    "rikugan.ui.context_bar",
+    "rikugan.ui.input_area",
+    "rikugan.ui.styles",
+    "rikugan.ui.tool_widgets",
+]:
+    sys.modules.pop(_mod_name, None)
+
 from rikugan.core.config import RikuganConfig
 from rikugan.core.types import Message, Role, TokenUsage, ToolCall, ToolResult
 from rikugan.ida.ui.session_controller import IdaSessionController
@@ -107,6 +126,21 @@ class TestIdaSessionController(unittest.TestCase):
         self.assertEqual(self.ctrl.session.id, saved_id)
         self.assertEqual(len(self.ctrl.session.messages), 1)
         self.assertEqual(self.ctrl.session.messages[0].content, "persisted")
+
+    def test_restore_sessions_returns_saved_sessions(self):
+        self.ctrl.session.add_message(Message(role=Role.USER, content="persisted one"))
+        self.cfg.checkpoint_auto_save = True
+        self.ctrl.on_agent_finished()
+
+        self.ctrl.new_chat()
+        self.ctrl.session.add_message(Message(role=Role.USER, content="persisted two"))
+        self.ctrl.on_agent_finished()
+
+        ctrl2 = IdaSessionController(self.cfg)
+        restored = ctrl2.restore_sessions()
+        self.assertEqual(len(restored), 2)
+        self.assertTrue(all(session.messages for _, session in restored))
+        ctrl2.shutdown()
 
     def test_restore_preserves_token_usage(self):
         """Full round-trip: save with token usage -> restore -> verify preserved."""

--- a/tests/core/test_error_hierarchy.py
+++ b/tests/core/test_error_hierarchy.py
@@ -37,6 +37,12 @@ from rikugan.core.errors import (
 )
 
 
+def _reload_anthropic_provider_module() -> None:
+    """Force the real provider module to load, not leftover test stubs."""
+    sys.modules.pop("rikugan.providers.anthropic_provider", None)
+    sys.modules.pop("rikugan.core.types", None)
+
+
 class TestErrorHierarchy(unittest.TestCase):
     """Every error type must be a subclass of RikuganError."""
 
@@ -124,6 +130,7 @@ class TestProviderErrorConsistency(unittest.TestCase):
     def test_anthropic_sdk_auth_error(self):
         """Anthropic maps anthropic.AuthenticationError → AuthenticationError."""
         import anthropic
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
         p = AnthropicProvider(api_key="test", model="test")
         resp = self._mock_httpx_response(401)
@@ -160,6 +167,7 @@ class TestProviderErrorConsistency(unittest.TestCase):
 
     def test_all_providers_generic_fallback(self):
         """All providers map unknown errors → ProviderError."""
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
         from rikugan.providers.openai_provider import OpenAIProvider
         from rikugan.providers.gemini_provider import GeminiProvider
@@ -177,6 +185,7 @@ class TestProviderHandleApiErrorReturnType(unittest.TestCase):
     """_handle_api_error must always raise (NoReturn); never silently return."""
 
     def test_anthropic_never_returns(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
         p = AnthropicProvider(api_key="test", model="test")
         with self.assertRaises(ProviderError):

--- a/tests/providers/test_anthropic_provider.py
+++ b/tests/providers/test_anthropic_provider.py
@@ -14,7 +14,14 @@ install_ida_mocks()
 from rikugan.core.types import Message, Role, ToolCall, ToolResult
 
 
+def _reload_anthropic_provider_module() -> None:
+    """Force the real provider module to load, not leftover test stubs."""
+    sys.modules.pop("rikugan.providers.anthropic_provider", None)
+    sys.modules.pop("rikugan.core.types", None)
+
+
 def _make_provider():
+    _reload_anthropic_provider_module()
     from rikugan.providers.anthropic_provider import AnthropicProvider
     return AnthropicProvider(api_key="test-key", model="claude-test")
 
@@ -172,18 +179,21 @@ class TestAnthropicAuthResolution(unittest.TestCase):
     """Test resolve_anthropic_auth priority order."""
 
     def test_explicit_api_key(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import resolve_anthropic_auth
         token, auth_type = resolve_anthropic_auth("sk-ant-api03-test")
         self.assertEqual(token, "sk-ant-api03-test")
         self.assertEqual(auth_type, "api_key")
 
     def test_explicit_oauth_token(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import resolve_anthropic_auth
         token, auth_type = resolve_anthropic_auth("sk-ant-oat01-test")
         self.assertEqual(token, "sk-ant-oat01-test")
         self.assertEqual(auth_type, "oauth")
 
     def test_env_var_api_key(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import resolve_anthropic_auth
         old = os.environ.get("ANTHROPIC_API_KEY")
         try:
@@ -198,6 +208,7 @@ class TestAnthropicAuthResolution(unittest.TestCase):
                 os.environ["ANTHROPIC_API_KEY"] = old
 
     def test_empty_returns_empty(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import resolve_anthropic_auth
         old_api = os.environ.pop("ANTHROPIC_API_KEY", None)
         old_oauth = os.environ.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
@@ -213,12 +224,14 @@ class TestAnthropicAuthResolution(unittest.TestCase):
                 os.environ["CLAUDE_CODE_OAUTH_TOKEN"] = old_oauth
 
     def test_auth_status_with_key(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
         p = AnthropicProvider(api_key="sk-test", model="test")
         label, status = p.auth_status()
         self.assertEqual(status, "ok")
 
     def test_auth_status_oauth(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
         p = AnthropicProvider(api_key="sk-ant-oat01-test", model="test")
         label, status = p.auth_status()

--- a/tests/providers/test_provider_adapters.py
+++ b/tests/providers/test_provider_adapters.py
@@ -11,10 +11,17 @@ from tests.mocks.ida_mock import install_ida_mocks
 install_ida_mocks()
 
 
+def _reload_anthropic_provider_module() -> None:
+    """Force the real provider module to load, not leftover test stubs."""
+    sys.modules.pop("rikugan.providers.anthropic_provider", None)
+    sys.modules.pop("rikugan.core.types", None)
+
+
 class TestBuiltinModels(unittest.TestCase):
     """All providers must declare non-empty builtin model lists."""
 
     def test_anthropic_builtin_models(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
         p = AnthropicProvider(api_key="test", model="test")
         models = p._builtin_models()
@@ -44,6 +51,7 @@ class TestProviderCapabilities(unittest.TestCase):
     """All providers must declare streaming and tool_use capabilities."""
 
     def test_anthropic_capabilities(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
         p = AnthropicProvider(api_key="test", model="test")
         caps = p.capabilities

--- a/tests/providers/test_provider_streaming.py
+++ b/tests/providers/test_provider_streaming.py
@@ -19,10 +19,17 @@ install_ida_mocks()
 from rikugan.core.types import Message, Role
 
 
+def _reload_anthropic_provider_module() -> None:
+    """Force the real provider module to load, not leftover test stubs."""
+    sys.modules.pop("rikugan.providers.anthropic_provider", None)
+    sys.modules.pop("rikugan.core.types", None)
+
+
 class TestAnthropicStreaming(unittest.TestCase):
     """Test AnthropicProvider.chat_stream with mock Anthropic stream events."""
 
     def _make_provider(self):
+        _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
         p = AnthropicProvider(api_key="test-key", model="claude-test")
         return p

--- a/tests/qt_stubs.py
+++ b/tests/qt_stubs.py
@@ -103,6 +103,7 @@ def ensure_pyside6_stubs() -> None:
     _installed = True
 
     _sentinel = type("_Qt", (), {})()
+    _sentinel.ItemDataRole = type("_ItemDataRole", (), {"UserRole": 32})()
 
     sys.modules.setdefault("PySide6", _stub_mod("PySide6"))
     sys.modules.setdefault(

--- a/tests/test_qt_compat.py
+++ b/tests/test_qt_compat.py
@@ -2,12 +2,23 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import unittest
 
 from tests.qt_stubs import ensure_pyside6_stubs
 
 ensure_pyside6_stubs()
 import rikugan.ui.qt_compat as qt_compat  # noqa: E402
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_UI_FILES_WITHOUT_SHIMS = {
+    "rikugan/ui/agent_tree.py",
+    "rikugan/ui/bulk_renamer.py",
+    "rikugan/ui/message_widgets.py",
+    "rikugan/ui/panel_core.py",
+    "rikugan/ui/settings_dialog.py",
+    "rikugan/ui/tool_widgets.py",
+}
 
 
 class TestQtCompat(unittest.TestCase):
@@ -30,6 +41,16 @@ class TestQtCompat(unittest.TestCase):
             "QMenu", "QMessageBox",
         ):
             self.assertTrue(hasattr(qt_compat, name), f"missing {name}")
+
+    def test_target_ui_files_do_not_use_exec_legacy_or_qt_flag_bitwise_or(self):
+        offenders: list[str] = []
+        for relative_path in sorted(_UI_FILES_WITHOUT_SHIMS):
+            text = (_REPO_ROOT / relative_path).read_text()
+            for line_no, line in enumerate(text.splitlines(), 1):
+                stripped = line.strip()
+                if "exec_(" in stripped or ("Qt." in stripped and "|" in stripped):
+                    offenders.append(f"{relative_path}:{line_no}:{stripped}")
+        self.assertEqual([], offenders)
 
 
 if __name__ == "__main__":

--- a/tests/test_qt_compat.py
+++ b/tests/test_qt_compat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 import unittest
 
@@ -11,14 +12,7 @@ ensure_pyside6_stubs()
 import rikugan.ui.qt_compat as qt_compat  # noqa: E402
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
-_UI_FILES_WITHOUT_SHIMS = {
-    "rikugan/ui/agent_tree.py",
-    "rikugan/ui/bulk_renamer.py",
-    "rikugan/ui/message_widgets.py",
-    "rikugan/ui/panel_core.py",
-    "rikugan/ui/settings_dialog.py",
-    "rikugan/ui/tool_widgets.py",
-}
+_UI_ROOT = _REPO_ROOT / "rikugan" / "ui"
 
 
 class TestQtCompat(unittest.TestCase):
@@ -42,14 +36,30 @@ class TestQtCompat(unittest.TestCase):
         ):
             self.assertTrue(hasattr(qt_compat, name), f"missing {name}")
 
+    def test_qt_flags_rejects_mixed_flag_types(self):
+        class _FlagA:
+            def __init__(self, value: int):
+                self.value = value
+
+        class _FlagB:
+            def __init__(self, value: int):
+                self.value = value
+
+        with self.assertRaises(TypeError):
+            qt_compat.qt_flags(_FlagA(1), _FlagB(2))
+
     def test_target_ui_files_do_not_use_exec_legacy_or_qt_flag_bitwise_or(self):
         offenders: list[str] = []
-        for relative_path in sorted(_UI_FILES_WITHOUT_SHIMS):
-            text = (_REPO_ROOT / relative_path).read_text()
-            for line_no, line in enumerate(text.splitlines(), 1):
-                stripped = line.strip()
-                if "exec_(" in stripped or ("Qt." in stripped and "|" in stripped):
-                    offenders.append(f"{relative_path}:{line_no}:{stripped}")
+        for path in sorted(_UI_ROOT.rglob("*.py")):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            relative_path = path.relative_to(_REPO_ROOT)
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "exec_":
+                    offenders.append(f"{relative_path}:{node.lineno}:exec_()")
+                if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+                    segment = ast.get_source_segment(path.read_text(), node) or ""
+                    if "Qt." in segment:
+                        offenders.append(f"{relative_path}:{node.lineno}:{segment}")
         self.assertEqual([], offenders)
 
 

--- a/tests/tools/test_chat_view.py
+++ b/tests/tools/test_chat_view.py
@@ -10,22 +10,33 @@ from unittest.mock import MagicMock
 from tests.qt_stubs import ensure_pyside6_stubs
 ensure_pyside6_stubs()
 
-# Stub all heavy submodules that chat_view imports
+# Stub all heavy submodules that chat_view imports.
+# Reinstall them unconditionally because other tests may have left behind
+# incomplete stubs in sys.modules.
 for _mod_name in [
     "rikugan.agent.turn",
     "rikugan.core.types",
 ]:
-    if _mod_name not in sys.modules:
-        _stub = types.ModuleType(_mod_name)
-        # Add commonly-needed attrs
-        for _attr in [
-            "PlanView", "TurnEvent",
-            "TurnEventType", "Message", "Role",
-        ]:
-            setattr(_stub, _attr, MagicMock())
-        sys.modules[_mod_name] = _stub
+    _stub = types.ModuleType(_mod_name)
+    # Add commonly-needed attrs
+    for _attr in [
+        "PlanView", "TurnEvent",
+        "TurnEventType", "Message", "Role",
+    ]:
+        setattr(_stub, _attr, MagicMock())
+    sys.modules[_mod_name] = _stub
+
+# Other tests may leave stubbed UI modules behind; force fresh imports.
+for _mod_name in [
+    "rikugan.ui.chat_view",
+    "rikugan.ui.message_widgets",
+    "rikugan.ui.plan_view",
+    "rikugan.ui.tool_widgets",
+]:
+    sys.modules.pop(_mod_name, None)
 
 from rikugan.ui.chat_view import _is_hidden_system_user_message, _TOOL_GROUP_MIN_CALLS  # noqa: E402
+from rikugan.ui.bulk_renamer import BulkRenamerWidget  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -68,6 +79,15 @@ class TestChatViewConstants(unittest.TestCase):
 
     def test_tool_group_min_calls_value(self):
         self.assertEqual(_TOOL_GROUP_MIN_CALLS, 2)
+
+
+class TestBulkRenamerLookup(unittest.TestCase):
+    def test_find_row_prefers_cached_mapping(self):
+        widget = object.__new__(BulkRenamerWidget)
+        widget._addr_to_row = {0x401000: 7}
+        widget._table = MagicMock()
+        self.assertEqual(widget._find_row_for_address(0x401000), 7)
+        widget._table.rowCount.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_markdown.py
+++ b/tests/tools/test_markdown.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import unittest
 
-from rikugan.ui.markdown import _inline, _inline_formatting, md_to_html
+from rikugan.ui.markdown import _has_markdown_syntax, _inline, _inline_formatting, md_to_html
 
 
 class TestMdToHtmlEmptyAndNone(unittest.TestCase):
@@ -14,6 +14,20 @@ class TestMdToHtmlEmptyAndNone(unittest.TestCase):
     def test_plain_text_passthrough(self):
         result = md_to_html("hello world")
         self.assertIn("hello world", result)
+
+
+class TestHasMarkdownSyntax(unittest.TestCase):
+    def test_plain_text_returns_false(self):
+        self.assertFalse(_has_markdown_syntax("hello world"))
+
+    def test_newline_only_returns_false(self):
+        self.assertFalse(_has_markdown_syntax("hello\nworld"))
+
+    def test_bold_marker_returns_true(self):
+        self.assertTrue(_has_markdown_syntax("**bold**"))
+
+    def test_header_marker_returns_true(self):
+        self.assertTrue(_has_markdown_syntax("# Title"))
 
 
 class TestMdToHtmlHeaders(unittest.TestCase):

--- a/tests/tools/test_panel_core.py
+++ b/tests/tools/test_panel_core.py
@@ -205,6 +205,7 @@ def _make_panel():
     panel._polling = False
     panel._pending_answer = False
     panel._chat_views = {}
+    panel._pending_restore_messages = {}
     panel._context_bar = None
     panel._mutation_panel = None
     panel._skills_refresh_timer = None
@@ -428,6 +429,24 @@ class TestStopSkillsRefreshTimer(unittest.TestCase):
         self.assertIsNone(panel._skills_refresh_timer)
         mock_timer.stop.assert_called_once()
         mock_timer.deleteLater.assert_called_once()
+
+
+class TestRestoreMessagesIfNeeded(unittest.TestCase):
+    def test_noop_when_no_pending_restore(self):
+        panel = _make_panel()
+        mock_view = MagicMock()
+        panel._chat_views["t1"] = mock_view
+        panel._restore_messages_if_needed("t1")
+        mock_view.restore_from_messages.assert_not_called()
+
+    def test_restores_pending_messages_once(self):
+        panel = _make_panel()
+        mock_view = MagicMock()
+        panel._chat_views["t1"] = mock_view
+        panel._pending_restore_messages["t1"] = ["m1", "m2"]
+        panel._restore_messages_if_needed("t1")
+        mock_view.restore_from_messages.assert_called_once_with(["m1", "m2"])
+        self.assertNotIn("t1", panel._pending_restore_messages)
 
 
 class TestUpdateTokenDisplay(unittest.TestCase):

--- a/tests/tools/test_settings_dialog.py
+++ b/tests/tools/test_settings_dialog.py
@@ -11,7 +11,9 @@ from tests.qt_stubs import ensure_pyside6_stubs
 
 ensure_pyside6_stubs()
 
-# Stub heavy dependencies
+# Stub heavy dependencies.
+# Reinstall these unconditionally because other tests may leave behind
+# incomplete stubs that are missing attributes needed here.
 for _mod_name in [
     "rikugan.core.config",
     "rikugan.core.logging",
@@ -21,21 +23,20 @@ for _mod_name in [
     "rikugan.providers.ollama_provider",
     "rikugan.providers.registry",
 ]:
-    if _mod_name not in sys.modules:
-        _stub = types.ModuleType(_mod_name)
-        for _attr in [
-            "RikuganConfig",
-            "log_debug",
-            "log_error",
-            "log_info",
-            "ModelInfo",
-            "resolve_anthropic_auth",
-            "resolve_auth_cached",
-            "DEFAULT_OLLAMA_URL",
-            "ProviderRegistry",
-        ]:
-            setattr(_stub, _attr, MagicMock())
-        sys.modules[_mod_name] = _stub
+    _stub = types.ModuleType(_mod_name)
+    for _attr in [
+        "RikuganConfig",
+        "log_debug",
+        "log_error",
+        "log_info",
+        "ModelInfo",
+        "resolve_anthropic_auth",
+        "resolve_auth_cached",
+        "DEFAULT_OLLAMA_URL",
+        "ProviderRegistry",
+    ]:
+        setattr(_stub, _attr, MagicMock())
+    sys.modules[_mod_name] = _stub
 
 # Ensure DEFAULT_OLLAMA_URL is a string on the stub (real module already has it)
 _ollama_mod = sys.modules.get("rikugan.providers.ollama_provider")
@@ -144,7 +145,7 @@ class TestResolveAuthCached(unittest.TestCase):
     """Tests for the auth_cache module (extracted from settings_dialog)."""
 
     def _get_ac(self):
-        return sys.modules["rikugan.providers.auth_cache"]
+        return _ac_stub
 
     def setUp(self):
         ac = self._get_ac()


### PR DESCRIPTION
Preserve Qt5 compatibility for IDA 9.0-9.1 while replacing legacy exec_ and enum flag bitwise patterns with shared helpers. Add a regression test to prevent shim-dependent UI code from creeping back in.