### PR TITLE
Fixes the installer/runtime dependency flow and cleans up the IDA UI theming path.

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -33,10 +33,33 @@ function Write-Ok      { param($Msg) Write-Host "[+] $Msg" -ForegroundColor Gree
 function Write-Warn    { param($Msg) Write-Host "[!] $Msg" -ForegroundColor Yellow }
 function Write-Err     { param($Msg) Write-Host "[-] $Msg" -ForegroundColor Red }
 
+function Test-UnicodeBannerSupport {
+    try {
+        $consoleEncoding = [Console]::OutputEncoding
+        $outputEncoding = $OutputEncoding
+
+        $isUtf8Console = $consoleEncoding -and $consoleEncoding.WebName -eq "utf-8"
+        $isUtf8Output = $outputEncoding -and $outputEncoding.WebName -eq "utf-8"
+        $hasModernTerminal = [bool]$env:WT_SESSION -or [bool]$env:TERM_PROGRAM
+
+        return $isUtf8Console -and $isUtf8Output -and $hasModernTerminal
+    }
+    catch {
+        return $false
+    }
+}
+
 function Show-Banner {
+    $titleLine = if (Test-UnicodeBannerSupport) {
+        "    |            六眼  Rikugan                 |"
+    }
+    else {
+        "    |              Rikugan                     |"
+    }
+
     Write-Host ""
     Write-Host "    +==========================================+" -ForegroundColor White
-    Write-Host "    |            六眼  Rikugan                 |" -ForegroundColor White
+    Write-Host $titleLine -ForegroundColor White
     Write-Host "    |     Reverse Engineering AI Agent         |" -ForegroundColor White
     Write-Host "    |        IDA Pro  .  Binary Ninja          |" -ForegroundColor White
     Write-Host "    +==========================================+" -ForegroundColor White

--- a/install_binaryninja.bat
+++ b/install_binaryninja.bat
@@ -59,8 +59,8 @@ if exist "%OLD_LINK%\" (
 :: ── Install Python dependencies ──────────────────────────────────
 call :install_requirements
 if !errorlevel! neq 0 (
-    echo [-] Failed to install Python dependencies from requirements.txt
-    exit /b 1
+    echo [!] Could not install one or more Python dependencies.
+    echo [!] Rikugan will still be installed, but features tied to missing packages will show warnings in the plugin.
 )
 
 if not exist "%PLUGINS_DIR%\"  mkdir "%PLUGINS_DIR%"

--- a/install_binaryninja.sh
+++ b/install_binaryninja.sh
@@ -161,8 +161,8 @@ install_requirements() {
 }
 
 if ! install_requirements; then
-    err "Failed to install Python dependencies from requirements.txt"
-    exit 1
+    warn "Could not install one or more Python dependencies."
+    warn "Rikugan will still be installed, but features tied to missing packages will show warnings in the plugin."
 fi
 
 mkdir -p "$PLUGINS_DIR"

--- a/install_ida.bat
+++ b/install_ida.bat
@@ -145,8 +145,8 @@ set "PIP_CMD=pip"
 call :try_install_requirements
 if !errorlevel! equ 0 goto deps_ok
 
-echo [-] Failed to install Python dependencies from requirements.txt
-exit /b 1
+echo [!] Could not install one or more Python dependencies.
+echo [!] Rikugan will still be installed, but features tied to missing packages will show warnings in the plugin.
 
 :deps_ok
 

--- a/install_ida.sh
+++ b/install_ida.sh
@@ -428,8 +428,8 @@ install_requirements() {
 }
 
 if ! install_requirements; then
-    err "Failed to install Python dependencies from requirements.txt"
-    exit 1
+    warn "Could not install one or more Python dependencies."
+    warn "Rikugan will still be installed, but features tied to missing packages will show warnings in the plugin."
 fi
 
 # ── Create directories ────────────────────────────────────────────────

--- a/rikugan/core/dependencies.py
+++ b/rikugan/core/dependencies.py
@@ -19,10 +19,7 @@ class DependencyStatus:
 
     @property
     def warning(self) -> str:
-        return (
-            f"{self.package_name} missing: {self.feature} will be unavailable "
-            f"(install `{self.package_name}`)."
-        )
+        return f"{self.package_name} missing: {self.feature} will be unavailable (install `{self.package_name}`)."
 
 
 _OPTIONAL_DEPENDENCIES: tuple[tuple[str, str, str, str], ...] = (

--- a/rikugan/core/dependencies.py
+++ b/rikugan/core/dependencies.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib.util
-import sys
 from dataclasses import dataclass
 
 
@@ -41,7 +40,7 @@ def _module_available(module_name: str) -> bool:
 
 def get_optional_dependency_statuses() -> list[DependencyStatus]:
     """Return current availability for optional runtime dependencies."""
-    statuses = [
+    return [
         DependencyStatus(
             key=key,
             module=module,
@@ -51,20 +50,6 @@ def get_optional_dependency_statuses() -> list[DependencyStatus]:
         )
         for key, module, package_name, feature in _OPTIONAL_DEPENDENCIES
     ]
-
-    # Python 3.11+ bundles tomllib, so the tomli backport is only optional there.
-    if sys.version_info < (3, 11):
-        statuses.append(
-            DependencyStatus(
-                key="tomli",
-                module="tomli",
-                package_name="tomli",
-                feature="external skills/MCP config discovery on Python 3.10",
-                available=_module_available("tomli"),
-            )
-        )
-
-    return statuses
 
 
 def get_missing_dependency_warnings() -> list[str]:

--- a/rikugan/core/dependencies.py
+++ b/rikugan/core/dependencies.py
@@ -1,0 +1,75 @@
+"""Helpers for optional Python dependency detection and UI warnings."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DependencyStatus:
+    """Runtime availability for an optional Python package."""
+
+    key: str
+    module: str
+    package_name: str
+    feature: str
+    available: bool
+
+    @property
+    def warning(self) -> str:
+        return (
+            f"{self.package_name} missing: {self.feature} will be unavailable "
+            f"(install `{self.package_name}`)."
+        )
+
+
+_OPTIONAL_DEPENDENCIES: tuple[tuple[str, str, str, str], ...] = (
+    ("anthropic", "anthropic", "anthropic", "Anthropic models"),
+    ("openai", "openai", "openai", "OpenAI and OpenAI-compatible models"),
+    ("gemini", "google.genai", "google-genai", "Gemini models"),
+    ("mcp", "mcp", "mcp", "MCP server integration"),
+    ("cryptography", "cryptography", "cryptography", "encrypted API-key storage"),
+    ("ida_domain", "ida_domain", "ida-domain", "advanced IDA scripting skill workflows"),
+)
+
+
+def _module_available(module_name: str) -> bool:
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ModuleNotFoundError, ValueError, AttributeError):
+        return False
+
+
+def get_optional_dependency_statuses() -> list[DependencyStatus]:
+    """Return current availability for optional runtime dependencies."""
+    statuses = [
+        DependencyStatus(
+            key=key,
+            module=module,
+            package_name=package_name,
+            feature=feature,
+            available=_module_available(module),
+        )
+        for key, module, package_name, feature in _OPTIONAL_DEPENDENCIES
+    ]
+
+    # Python 3.11+ bundles tomllib, so the tomli backport is only optional there.
+    if sys.version_info < (3, 11):
+        statuses.append(
+            DependencyStatus(
+                key="tomli",
+                module="tomli",
+                package_name="tomli",
+                feature="external skills/MCP config discovery on Python 3.10",
+                available=_module_available("tomli"),
+            )
+        )
+
+    return statuses
+
+
+def get_missing_dependency_warnings() -> list[str]:
+    """Return human-readable warnings for missing optional dependencies."""
+    return [status.warning for status in get_optional_dependency_statuses() if not status.available]

--- a/rikugan/core/external_sources.py
+++ b/rikugan/core/external_sources.py
@@ -2,12 +2,12 @@
 
 Platform notes
 --------------
-Both Claude Code and Codex use ``~/.claude/`` and ``~/.codex/`` respectively on
-**all** platforms (macOS, Linux, Windows).  Python's ``Path.home()`` resolves
-``~`` correctly on each OS (``%USERPROFILE%`` on Windows, ``$HOME`` elsewhere).
+Claude Code and Codex skills/config are resolved through helper functions in
+this module so the rest of the UI does not hardcode Unix-style ``~/.foo``
+labels. On Windows these helpers still resolve under the user's profile
+directory unless an explicit override is supported.
 
-Codex honours the ``CODEX_HOME`` environment variable as an override for
-``~/.codex/``.
+Codex honours the ``CODEX_HOME`` environment variable as an override.
 
 Claude Code enterprise/managed MCP configs live in platform-specific paths:
 
@@ -41,23 +41,39 @@ from ..skills.loader import SkillDefinition, discover_skills
 
 
 def get_claude_code_base() -> Path:
-    """Return the Claude Code config directory (~/.claude).
-
-    Same path on macOS, Linux, and Windows.
-    """
+    """Return the Claude Code config directory."""
     return Path.home() / ".claude"
 
 
 def get_codex_base() -> Path:
     """Return the Codex CLI config directory.
 
-    Respects the ``CODEX_HOME`` environment variable; falls back to
-    ``~/.codex/``.  Same fallback path on macOS, Linux, and Windows.
+    Respects the ``CODEX_HOME`` environment variable; falls back to the user's
+    Codex config directory under their profile.
     """
     codex_home = os.environ.get("CODEX_HOME", "").strip()
     if codex_home:
         return Path(codex_home)
     return Path.home() / ".codex"
+
+
+def get_claude_skills_dir() -> Path:
+    """Return the Claude Code skills directory."""
+    return get_claude_code_base() / "skills"
+
+
+def get_codex_skills_dir() -> Path:
+    """Return the Codex skills directory."""
+    return get_codex_base() / "skills"
+
+
+def get_external_skills_title(source_key: str) -> str:
+    """Return a settings-tab title with the resolved directory path."""
+    if source_key == "claude":
+        return f"Claude Code Skills ({get_claude_skills_dir()})"
+    if source_key == "codex":
+        return f"Codex Skills ({get_codex_skills_dir()})"
+    return f"{source_key} Skills"
 
 
 def _get_claude_managed_mcp_path() -> Path | None:
@@ -78,15 +94,15 @@ def _get_claude_managed_mcp_path() -> Path | None:
 
 
 def discover_claude_skills() -> list[SkillDefinition]:
-    """Scan ``~/.claude/skills/`` for Claude Code skills."""
-    skills_dir = get_claude_code_base() / "skills"
+    """Scan the Claude Code skills directory."""
+    skills_dir = get_claude_skills_dir()
     log_debug(f"Scanning Claude Code skills: {skills_dir}")
     return discover_skills(str(skills_dir))
 
 
 def discover_codex_skills() -> list[SkillDefinition]:
-    """Scan ``~/.codex/skills/`` for Codex skills."""
-    skills_dir = get_codex_base() / "skills"
+    """Scan the Codex skills directory."""
+    skills_dir = get_codex_skills_dir()
     log_debug(f"Scanning Codex skills: {skills_dir}")
     return discover_skills(str(skills_dir))
 

--- a/rikugan/core/log_sinks.py
+++ b/rikugan/core/log_sinks.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import sys
+import tempfile
 from collections.abc import Callable
 
 from .host import get_user_config_base_dir
@@ -110,6 +111,8 @@ IDAHandler = HostOutputHandler
 
 def _log_file_path() -> str:
     base = get_user_config_base_dir()
+    if os.name == "nt" and os.path.isabs(base) and not os.path.splitdrive(base)[0]:
+        base = os.path.join(tempfile.gettempdir(), base.lstrip("/\\").replace("/", os.sep))
     d = os.path.join(base, "rikugan")
     os.makedirs(d, exist_ok=True)
     return os.path.join(d, "rikugan_debug.log")

--- a/rikugan/providers/auth_cache.py
+++ b/rikugan/providers/auth_cache.py
@@ -7,10 +7,23 @@ for auth resolution — both UI and provider construction go through here.
 
 from __future__ import annotations
 
-from .anthropic_provider import resolve_anthropic_auth
-
 _cached_oauth: tuple[str, str] | None = None  # (token, auth_type)
 _keychain_consent: bool = False  # set by UI after user accepts OAuth risk
+
+
+def _resolve_anthropic_auth(
+    explicit_key: str = "",
+    *,
+    allow_keychain: bool = True,
+) -> tuple[str, str]:
+    """Import and call Anthropic auth resolution lazily.
+
+    This avoids early-import circularities during host/UI bootstrap where
+    ``auth_cache`` may be imported before provider modules are fully ready.
+    """
+    from .anthropic_provider import resolve_anthropic_auth
+
+    return resolve_anthropic_auth(explicit_key, allow_keychain=allow_keychain)
 
 
 def set_keychain_consent(accepted: bool) -> None:
@@ -29,10 +42,10 @@ def resolve_auth_cached(explicit_key: str = "") -> tuple[str, str]:
     """
     global _cached_oauth
     if explicit_key:
-        return resolve_anthropic_auth(explicit_key)
+        return _resolve_anthropic_auth(explicit_key)
     if _cached_oauth is not None:
         return _cached_oauth
-    result = resolve_anthropic_auth("", allow_keychain=_keychain_consent)
+    result = _resolve_anthropic_auth("", allow_keychain=_keychain_consent)
     # Only cache successful resolutions
     if result[0]:
         _cached_oauth = result
@@ -41,7 +54,7 @@ def resolve_auth_cached(explicit_key: str = "") -> tuple[str, str]:
 
 def has_keychain_token() -> bool:
     """Check if a keychain OAuth token exists (ignoring consent)."""
-    token, auth_type = resolve_anthropic_auth("", allow_keychain=True)
+    token, auth_type = _resolve_anthropic_auth("", allow_keychain=True)
     return auth_type == "oauth" and bool(token)
 
 

--- a/rikugan/providers/registry.py
+++ b/rikugan/providers/registry.py
@@ -2,24 +2,28 @@
 
 from __future__ import annotations
 
+import importlib
+from dataclasses import dataclass
 from typing import Any
 
+from ..core.dependencies import get_missing_dependency_warnings
 from ..core.errors import ProviderError
-from .anthropic_provider import AnthropicProvider
 from .base import LLMProvider
-from .gemini_provider import GeminiProvider
-from .minimax_provider import MiniMaxProvider
-from .ollama_provider import OllamaProvider
-from .openai_compat import OpenAICompatProvider
-from .openai_provider import OpenAIProvider
 
-_BUILTIN_PROVIDERS: dict[str, type[LLMProvider]] = {
-    "anthropic": AnthropicProvider,
-    "openai": OpenAIProvider,
-    "openai_compat": OpenAICompatProvider,
-    "gemini": GeminiProvider,
-    "ollama": OllamaProvider,
-    "minimax": MiniMaxProvider,
+
+@dataclass(frozen=True)
+class _ProviderSpec:
+    module_path: str
+    class_name: str
+
+
+_BUILTIN_PROVIDERS: dict[str, _ProviderSpec] = {
+    "anthropic": _ProviderSpec(".anthropic_provider", "AnthropicProvider"),
+    "openai": _ProviderSpec(".openai_provider", "OpenAIProvider"),
+    "openai_compat": _ProviderSpec(".openai_compat", "OpenAICompatProvider"),
+    "gemini": _ProviderSpec(".gemini_provider", "GeminiProvider"),
+    "ollama": _ProviderSpec(".ollama_provider", "OllamaProvider"),
+    "minimax": _ProviderSpec(".minimax_provider", "MiniMaxProvider"),
 }
 
 
@@ -27,20 +31,46 @@ class ProviderRegistry:
     """Factory for creating and managing LLM providers."""
 
     def __init__(self) -> None:
-        self._providers: dict[str, type[LLMProvider]] = dict(_BUILTIN_PROVIDERS)
+        self._providers: dict[str, _ProviderSpec] = dict(_BUILTIN_PROVIDERS)
+        self._provider_classes: dict[str, type[LLMProvider]] = {}
         self._instances: dict[str, LLMProvider] = {}
 
+    def _resolve_provider_class(self, name: str) -> type[LLMProvider]:
+        cached = self._provider_classes.get(name)
+        if cached is not None:
+            return cached
+
+        spec = self._providers.get(name)
+        if spec is None:
+            raise ProviderError(f"Unknown provider: {name}. Available: {self.list_providers()}")
+
+        try:
+            module = importlib.import_module(spec.module_path, package=__package__)
+            provider_cls = getattr(module, spec.class_name)
+        except (ImportError, AttributeError) as exc:
+            raise ProviderError(
+                f"Provider '{name}' could not be loaded: {exc}",
+                provider=name,
+            ) from exc
+
+        self._provider_classes[name] = provider_cls
+        return provider_cls
+
     def register(self, name: str, provider_cls: type[LLMProvider]) -> None:
-        self._providers[name] = provider_cls
+        self._provider_classes[name] = provider_cls
 
     def register_custom_providers(self, names: list[str]) -> None:
         """Register custom provider names as OpenAI-compatible endpoints."""
         for name in names:
             if name not in _BUILTIN_PROVIDERS:
-                self._providers[name] = OpenAICompatProvider
+                self._providers[name] = _ProviderSpec(".openai_compat", "OpenAICompatProvider")
 
     def list_providers(self) -> list[str]:
         return list(self._providers.keys())
+
+    def dependency_warnings(self) -> list[str]:
+        """Return user-facing warnings for missing optional runtime packages."""
+        return get_missing_dependency_warnings()
 
     def create(
         self,
@@ -51,12 +81,12 @@ class ProviderRegistry:
         **kwargs: Any,
     ) -> LLMProvider:
         """Create a new provider instance."""
-        cls = self._providers.get(name)
-        if cls is None:
-            raise ProviderError(f"Unknown provider: {name}. Available: {self.list_providers()}")
+        cls = self._resolve_provider_class(name)
 
-        # Custom OpenAI-compatible providers need their name passed through
-        if cls is OpenAICompatProvider and name != "openai_compat":
+        # Custom OpenAI-compatible providers need their name passed through.
+        if name not in _BUILTIN_PROVIDERS:
+            kwargs.setdefault("provider_name", name)
+        elif self._providers.get(name) == _BUILTIN_PROVIDERS["openai_compat"] and name != "openai_compat":
             kwargs.setdefault("provider_name", name)
 
         instance = cls(api_key=api_key, api_base=api_base, model=model, **kwargs)

--- a/rikugan/ui/agent_tree.py
+++ b/rikugan/ui/agent_tree.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QAbstractItemView,
     QComboBox,
@@ -20,6 +19,7 @@ from .qt_compat import (
     Signal,
     qt_flags,
 )
+from .styles import maybe_host_stylesheet
 
 _STATUS_COLORS: dict[str, str] = {
     "PENDING": "#808080",

--- a/rikugan/ui/agent_tree.py
+++ b/rikugan/ui/agent_tree.py
@@ -73,8 +73,7 @@ _COMBO_STYLE = maybe_host_stylesheet(
 _STATUS_LABEL_STYLE = maybe_host_stylesheet("color: #808080; font-size: 11px;")
 
 _PREVIEW_STYLE = maybe_host_stylesheet(
-    "QTextEdit { background: #252525; color: #d4d4d4; border: 1px solid #3c3c3c; "
-    "font-size: 11px; padding: 4px; }"
+    "QTextEdit { background: #252525; color: #d4d4d4; border: 1px solid #3c3c3c; font-size: 11px; padding: 4px; }"
 )
 
 

--- a/rikugan/ui/agent_tree.py
+++ b/rikugan/ui/agent_tree.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QAbstractItemView,
     QComboBox,
@@ -34,6 +35,7 @@ _BTN_STYLE = (
     "QPushButton:hover { background: #3c3c3c; }"
     "QPushButton:disabled { color: #555; }"
 )
+_BTN_STYLE = maybe_host_stylesheet(_BTN_STYLE)
 
 _TREE_STYLE = """
     QTreeWidget {
@@ -61,6 +63,19 @@ _TREE_STYLE = """
         font-size: 10px;
     }
 """
+_TREE_STYLE = maybe_host_stylesheet(_TREE_STYLE)
+
+_COMBO_STYLE = maybe_host_stylesheet(
+    "QComboBox { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
+    "border-radius: 4px; padding: 3px 6px; font-size: 11px; }"
+)
+
+_STATUS_LABEL_STYLE = maybe_host_stylesheet("color: #808080; font-size: 11px;")
+
+_PREVIEW_STYLE = maybe_host_stylesheet(
+    "QTextEdit { background: #252525; color: #d4d4d4; border: 1px solid #3c3c3c; "
+    "font-size: 11px; padding: 4px; }"
+)
 
 
 @dataclass
@@ -108,10 +123,7 @@ class AgentTreeWidget(QWidget):
 
         self._filter_combo = QComboBox()
         self._filter_combo.setFixedWidth(130)
-        self._filter_combo.setStyleSheet(
-            "QComboBox { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
-            "border-radius: 4px; padding: 3px 6px; font-size: 11px; }"
-        )
+        self._filter_combo.setStyleSheet(_COMBO_STYLE)
         self._filter_combo.addItems(["All Agents", "General", "Bulk Rename"])
         self._filter_combo.currentTextChanged.connect(self._apply_filter)
         toolbar.addWidget(self._filter_combo)
@@ -119,7 +131,7 @@ class AgentTreeWidget(QWidget):
         toolbar.addStretch()
 
         self._status_label = QLabel("0 running / 0 completed")
-        self._status_label.setStyleSheet("color: #808080; font-size: 11px;")
+        self._status_label.setStyleSheet(_STATUS_LABEL_STYLE)
         toolbar.addWidget(self._status_label)
 
         main_layout.addLayout(toolbar)
@@ -147,10 +159,7 @@ class AgentTreeWidget(QWidget):
         self._preview.setObjectName("agent_preview")
         self._preview.setReadOnly(True)
         self._preview.setFixedHeight(80)
-        self._preview.setStyleSheet(
-            "QTextEdit { background: #252525; color: #d4d4d4; border: 1px solid #3c3c3c; "
-            "font-size: 11px; padding: 4px; }"
-        )
+        self._preview.setStyleSheet(_PREVIEW_STYLE)
         self._preview.setPlaceholderText("Select an agent to preview its output...")
         main_layout.addWidget(self._preview)
 

--- a/rikugan/ui/bulk_renamer.py
+++ b/rikugan/ui/bulk_renamer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QAbstractItemView,
     QCheckBox,
@@ -26,6 +25,7 @@ from .qt_compat import (
     Signal,
     qt_flags,
 )
+from .styles import maybe_host_stylesheet
 
 _BTN_STYLE = (
     "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "

--- a/rikugan/ui/bulk_renamer.py
+++ b/rikugan/ui/bulk_renamer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QAbstractItemView,
     QCheckBox,
@@ -32,6 +33,7 @@ _BTN_STYLE = (
     "QPushButton:hover { background: #3c3c3c; }"
     "QPushButton:disabled { color: #555; }"
 )
+_BTN_STYLE = maybe_host_stylesheet(_BTN_STYLE)
 
 _STOP_BTN_STYLE = (
     "QPushButton { background: #2d2d2d; color: #c42b1c; border: 1px solid #c42b1c; "
@@ -39,6 +41,7 @@ _STOP_BTN_STYLE = (
     "QPushButton:hover { background: #3c3c3c; }"
     "QPushButton:disabled { color: #555; border-color: #555; }"
 )
+_STOP_BTN_STYLE = maybe_host_stylesheet(_STOP_BTN_STYLE)
 
 _START_BTN_STYLE = (
     "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #d4d4d4; "
@@ -46,6 +49,7 @@ _START_BTN_STYLE = (
     "QPushButton:hover { background: #3c3c3c; }"
     "QPushButton:disabled { color: #555; border-color: #555; }"
 )
+_START_BTN_STYLE = maybe_host_stylesheet(_START_BTN_STYLE)
 
 _TABLE_STYLE = """
     QTableWidget {
@@ -70,32 +74,42 @@ _TABLE_STYLE = """
         font-size: 10px;
     }
 """
+_TABLE_STYLE = maybe_host_stylesheet(_TABLE_STYLE)
 
 _FILTER_STYLE = (
     "QLineEdit { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
     "border-radius: 3px; padding: 3px 6px; font-size: 11px; }"
     "QLineEdit:focus { border-color: #4ec9b0; }"
 )
+_FILTER_STYLE = maybe_host_stylesheet(_FILTER_STYLE)
 
 _COMBO_STYLE = (
     "QComboBox { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
     "border-radius: 3px; padding: 3px 6px; font-size: 11px; }"
 )
+_COMBO_STYLE = maybe_host_stylesheet(_COMBO_STYLE)
 
 _NUM_INPUT_STYLE = (
     "QLineEdit { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
     "border-radius: 3px; padding: 2px 4px; font-size: 11px; }"
 )
+_NUM_INPUT_STYLE = maybe_host_stylesheet(_NUM_INPUT_STYLE)
 
 _PROGRESS_STYLE = (
     "QProgressBar { background: #2d2d2d; border: 1px solid #3c3c3c; "
     "border-radius: 3px; text-align: center; color: #d4d4d4; font-size: 10px; }"
     "QProgressBar::chunk { background: #808080; border-radius: 2px; }"
 )
+_PROGRESS_STYLE = maybe_host_stylesheet(_PROGRESS_STYLE)
 
 _RADIO_STYLE = "QRadioButton { color: #d4d4d4; font-size: 11px; spacing: 4px; }"
+_RADIO_STYLE = maybe_host_stylesheet(_RADIO_STYLE)
 
 _CHECK_STYLE = "QCheckBox { spacing: 0px; } QCheckBox::indicator { width: 14px; height: 14px; }"
+_CHECK_STYLE = maybe_host_stylesheet(_CHECK_STYLE)
+
+_MUTED_LABEL_STYLE = maybe_host_stylesheet("color: #808080; font-size: 11px;")
+_LABEL_STYLE = maybe_host_stylesheet("color: #d4d4d4; font-size: 11px;")
 
 _STATUS_COLORS: dict[str, str] = {
     "queued": "#808080",
@@ -173,7 +187,7 @@ class BulkRenamerWidget(QWidget):
         top_bar.addWidget(self._filter_combo)
 
         self._selection_label = QLabel("0 / 0 selected")
-        self._selection_label.setStyleSheet("color: #808080; font-size: 11px;")
+        self._selection_label.setStyleSheet(_MUTED_LABEL_STYLE)
         top_bar.addWidget(self._selection_label)
 
         main_layout.addLayout(top_bar)
@@ -225,7 +239,7 @@ class BulkRenamerWidget(QWidget):
         analysis_bar.setSpacing(6)
 
         mode_label = QLabel("Mode:")
-        mode_label.setStyleSheet("color: #d4d4d4; font-size: 11px;")
+        mode_label.setStyleSheet(_LABEL_STYLE)
         analysis_bar.addWidget(mode_label)
 
         self._quick_radio = QRadioButton("Quick")
@@ -241,7 +255,7 @@ class BulkRenamerWidget(QWidget):
         analysis_bar.addSpacing(12)
 
         batch_label = QLabel("Batch:")
-        batch_label.setStyleSheet("color: #d4d4d4; font-size: 11px;")
+        batch_label.setStyleSheet(_LABEL_STYLE)
         batch_label.setToolTip("Quick: functions per LLM prompt. Deep: ignored (1 agent per function).")
         analysis_bar.addWidget(batch_label)
 
@@ -255,7 +269,7 @@ class BulkRenamerWidget(QWidget):
         analysis_bar.addWidget(self._batch_input)
 
         concurrent_label = QLabel("Jobs:")
-        concurrent_label.setStyleSheet("color: #d4d4d4; font-size: 11px;")
+        concurrent_label.setStyleSheet(_LABEL_STYLE)
         concurrent_label.setToolTip("Max parallel agents/requests running at the same time")
         analysis_bar.addWidget(concurrent_label)
 
@@ -304,7 +318,7 @@ class BulkRenamerWidget(QWidget):
         action_bar.addWidget(self._progress, 1)
 
         self._progress_label = QLabel("0 / 0")
-        self._progress_label.setStyleSheet("color: #808080; font-size: 11px;")
+        self._progress_label.setStyleSheet(_MUTED_LABEL_STYLE)
         action_bar.addWidget(self._progress_label)
 
         main_layout.addLayout(action_bar)

--- a/rikugan/ui/chat_view.py
+++ b/rikugan/ui/chat_view.py
@@ -104,16 +104,16 @@ class ChatView(QScrollArea):
         self._user_answer_callback = callback
 
     def add_user_message(self, text: str) -> None:
-        widget = UserMessageWidget(text)
+        widget = UserMessageWidget(text, parent=self._container)
         self._insert_widget(widget)
         self._current_assistant = None
 
     def add_error_message(self, text: str) -> None:
-        self._insert_widget(ErrorMessageWidget(text))
+        self._insert_widget(ErrorMessageWidget(text, parent=self._container))
         self._scroll_to_bottom()
 
     def add_queued_message(self, text: str) -> None:
-        self._insert_widget(QueuedMessageWidget(text))
+        self._insert_widget(QueuedMessageWidget(text, parent=self._container))
         self._scroll_to_bottom()
 
     def remove_queued_messages(self) -> None:
@@ -138,7 +138,7 @@ class ChatView(QScrollArea):
     def _show_thinking(self) -> None:
         if self._thinking is not None:
             return
-        self._thinking = ThinkingWidget()
+        self._thinking = ThinkingWidget(parent=self._container)
         self._thinking_shown_at = time.monotonic()
         self._insert_widget(self._thinking)
         self._scroll_to_bottom()
@@ -251,7 +251,7 @@ class ChatView(QScrollArea):
         elif etype == TurnEventType.ERROR:
             self._hide_thinking()
             self._reset_tool_run()
-            self._insert_widget(ErrorMessageWidget(event.error or "Unknown error"))
+            self._insert_widget(ErrorMessageWidget(event.error or "Unknown error", parent=self._container))
             self._scroll_to_bottom()
 
     def _handle_text_event(self, event: TurnEvent) -> None:
@@ -259,7 +259,7 @@ class ChatView(QScrollArea):
         self._reset_tool_run()
         if event.type == TurnEventType.TEXT_DELTA:
             if self._current_assistant is None:
-                self._current_assistant = AssistantMessageWidget()
+                self._current_assistant = AssistantMessageWidget(parent=self._container)
                 self._insert_widget(self._current_assistant)
             self._current_assistant.append_text(event.text)
             self._scroll_to_bottom()
@@ -272,7 +272,7 @@ class ChatView(QScrollArea):
         etype = event.type
         if etype == TurnEventType.TOOL_CALL_START:
             self._hide_thinking()
-            tw = ToolCallWidget(event.tool_name, event.tool_call_id)
+            tw = ToolCallWidget(event.tool_name, event.tool_call_id, parent=self._container)
             self._tool_widgets[event.tool_call_id] = tw
             self._register_tool_widget(event.tool_name, event.tool_call_id, tw)
             self._scroll_to_bottom()
@@ -301,6 +301,7 @@ class ChatView(QScrollArea):
                 event.tool_name,
                 event.tool_args,
                 event.text,
+                parent=self._container,
             )
             widget.set_approved_callback(self._on_tool_approval)
             self._insert_widget(widget)
@@ -321,7 +322,7 @@ class ChatView(QScrollArea):
         elif etype == TurnEventType.CANCELLED:
             self._hide_thinking()
             self._reset_tool_run()
-            self._insert_widget(ErrorMessageWidget("Cancelled by user"))
+            self._insert_widget(ErrorMessageWidget("Cancelled by user", parent=self._container))
             self._scroll_to_bottom()
 
     def _handle_plan_event(self, event: TurnEvent) -> None:
@@ -329,7 +330,7 @@ class ChatView(QScrollArea):
         if etype == TurnEventType.PLAN_GENERATED:
             self._hide_thinking()
             self._reset_tool_run()
-            self._plan_view = PlanView()
+            self._plan_view = PlanView(parent=self._container)
             if event.plan_steps:
                 self._plan_view.set_plan(event.plan_steps)
 
@@ -365,6 +366,7 @@ class ChatView(QScrollArea):
                     meta.get("from_phase", ""),
                     meta.get("to_phase", ""),
                     event.text,
+                    parent=self._container,
                 )
             )
         else:  # EXPLORATION_FINDING
@@ -374,6 +376,7 @@ class ChatView(QScrollArea):
                     event.text,
                     meta.get("address"),
                     meta.get("relevance", "medium"),
+                    parent=self._container,
                 )
             )
         self._scroll_to_bottom()
@@ -390,6 +393,7 @@ class ChatView(QScrollArea):
                     path=meta.get("path", ""),
                     preview=meta.get("preview", ""),
                     review_passed=meta.get("review_passed", True),
+                    parent=self._container,
                 )
             )
             self._scroll_to_bottom()
@@ -400,17 +404,17 @@ class ChatView(QScrollArea):
         if event.type == TurnEventType.SUBAGENT_SPAWNED:
             name = event.text
             agent_type = meta.get("agent_type", "custom")
-            self._insert_widget(SubagentEventWidget("spawned", name, f"type: {agent_type}"))
+            self._insert_widget(SubagentEventWidget("spawned", name, f"type: {agent_type}", parent=self._container))
         elif event.type == TurnEventType.SUBAGENT_COMPLETED:
             name = meta.get("name", "")
             turns = meta.get("turn_count", 0)
             elapsed = meta.get("elapsed", 0.0)
             detail = f"{turns} turns, {elapsed:.0f}s"
-            self._insert_widget(SubagentEventWidget("completed", name, detail))
+            self._insert_widget(SubagentEventWidget("completed", name, detail, parent=self._container))
         elif event.type == TurnEventType.SUBAGENT_FAILED:
             name = meta.get("name", "")
             error = event.error or "Unknown error"
-            self._insert_widget(SubagentEventWidget("failed", name, error))
+            self._insert_widget(SubagentEventWidget("failed", name, error, parent=self._container))
         self._scroll_to_bottom()
 
     def _handle_question_event(self, event: TurnEvent) -> None:
@@ -420,7 +424,7 @@ class ChatView(QScrollArea):
             options = ["Save All", "Discard All"]
         else:  # USER_QUESTION
             options = event.metadata.get("options", [])
-        widget = UserQuestionWidget(event.text, options)
+        widget = UserQuestionWidget(event.text, options, parent=self._container)
         widget.set_option_selected_callback(self._on_user_answer)
         self._insert_widget(widget)
         self._scroll_to_bottom()
@@ -449,12 +453,12 @@ class ChatView(QScrollArea):
             elif msg.role == Role.ASSISTANT:
                 self._reset_tool_run()
                 if msg.content:
-                    w = AssistantMessageWidget()
+                    w = AssistantMessageWidget(parent=self._container)
                     w.set_text(msg.content)
                     self._insert_widget(w)
 
                 for tc in msg.tool_calls:
-                    tw = ToolCallWidget(tc.name, tc.id)
+                    tw = ToolCallWidget(tc.name, tc.id, parent=self._container)
                     try:
                         args_str = json.dumps(tc.arguments, indent=2)
                     except (TypeError, ValueError):

--- a/rikugan/ui/input_area.py
+++ b/rikugan/ui/input_area.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from .styles import build_input_area_stylesheet, host_stylesheet, use_native_host_theme
 from .qt_compat import (
     QEvent,
     QFrame,
@@ -13,6 +12,7 @@ from .qt_compat import (
     QVBoxLayout,
     QWidget,
 )
+from .styles import build_input_area_stylesheet, host_stylesheet, use_native_host_theme
 
 
 class _SkillPopup(QFrame):

--- a/rikugan/ui/input_area.py
+++ b/rikugan/ui/input_area.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from .styles import build_input_area_stylesheet, host_stylesheet, use_native_host_theme
 from .qt_compat import (
+    QEvent,
     QFrame,
     QLabel,
     QPlainTextEdit,
@@ -28,10 +30,13 @@ class _SkillPopup(QFrame):
         self.setObjectName("skill_popup")
         self.setWindowFlags(Qt.WindowType.ToolTip)
         self.setStyleSheet(
-            "QFrame#skill_popup { background: #2d2d2d; border: 1px solid #555; "
-            "border-radius: 4px; padding: 2px; }"
-            "QLabel { color: #d4d4d4; padding: 3px 8px; }"
-            'QLabel[selected="true"] { background: #094771; border-radius: 3px; }'
+            host_stylesheet(
+                "QFrame#skill_popup { background: #2d2d2d; border: 1px solid #555; "
+                "border-radius: 4px; padding: 2px; }"
+                "QLabel { color: #d4d4d4; padding: 3px 8px; }"
+                'QLabel[selected="true"] { background: #094771; border-radius: 3px; }',
+                'QLabel[selected="true"] { font-weight: bold; }',
+            )
         )
         self._layout = QVBoxLayout(self)
         self._layout.setContentsMargins(2, 2, 2, 2)
@@ -106,6 +111,9 @@ class InputArea(QPlainTextEdit):
         self._popup: _SkillPopup | None = None
         self._submit_callback = None  # Callable[[str], None]
         self._cancel_callback = None  # Callable[[], None]
+        self._applying_theme = False
+        self._theme_css = ""
+        self._apply_theme()
 
     def set_submit_callback(self, callback) -> None:
         """Set the callback for submit (Enter key). Callback signature: (str) -> None."""
@@ -168,6 +176,35 @@ class InputArea(QPlainTextEdit):
             self.setPlaceholderText("Ask about this binary... (/ for skills, /modify to patch)")
         else:
             self.setPlaceholderText("Rikugan is thinking...")
+
+    def _apply_theme(self) -> None:
+        """Apply host-aware styling to the text editor."""
+        if not use_native_host_theme() or self._applying_theme:
+            return
+        css = build_input_area_stylesheet(self)
+        if css == self._theme_css:
+            return
+        self._applying_theme = True
+        try:
+            self.setStyleSheet(css)
+            self._theme_css = css
+        finally:
+            self._applying_theme = False
+
+    def showEvent(self, event) -> None:
+        super().showEvent(event)
+        self._apply_theme()
+
+    def changeEvent(self, event) -> None:
+        super().changeEvent(event)
+        if not use_native_host_theme():
+            return
+        event_type = getattr(event, "type", lambda: None)()
+        palette_change = getattr(QEvent, "PaletteChange", None)
+        app_palette_change = getattr(QEvent, "ApplicationPaletteChange", None)
+        parent_change = getattr(QEvent, "ParentChange", None)
+        if event_type in {palette_change, app_palette_change, parent_change}:
+            self._apply_theme()
 
     # ------------------------------------------------------------------
     # Autocomplete

--- a/rikugan/ui/markdown.py
+++ b/rikugan/ui/markdown.py
@@ -30,8 +30,8 @@ _MARKDOWN_HINT_RE = re.compile(
 def _theme_markdown_styles(source=None) -> dict[str, str]:
     if use_native_host_theme():
         return {
-            "inline_code_style": 'font-family:Consolas,"Courier New",monospace;',
-            "block_code_style": 'font-family:Consolas,"Courier New",monospace; white-space:pre-wrap;',
+            "inline_code_style": "font-family:monospace;",
+            "block_code_style": "font-family:monospace; white-space:pre-wrap;",
             "link_style": "text-decoration: underline;",
             "hr_style": "",
             "heading_style": "font-weight:bold;",
@@ -81,11 +81,7 @@ def md_to_html(text: str, source=None) -> str:
     def _stash_block(m: re.Match) -> str:
         lang = m.group(1) or ""
         code = html.escape(m.group(2).strip("\n"))
-        lang_tag = (
-            f'<span style="{theme["lang_tag_style"]}">{html.escape(lang)}</span><br>'
-            if lang
-            else ""
-        )
+        lang_tag = f'<span style="{theme["lang_tag_style"]}">{html.escape(lang)}</span><br>' if lang else ""
         block_html = f'<div style="{theme["block_code_style"]}">{lang_tag}{code}</div>'
         blocks.append(block_html)
         return f"\x00BLOCK{len(blocks) - 1}\x00"

--- a/rikugan/ui/markdown.py
+++ b/rikugan/ui/markdown.py
@@ -19,32 +19,46 @@ from __future__ import annotations
 import html
 import re
 
-# -- Colors matching the dark theme --
-_CODE_BG = "#2d2d2d"
-_CODE_FG = "#ce9178"
-_CODE_BORDER = "#3c3c3c"
-_BLOCK_BG = "#1a1a1a"
-_BLOCK_FG = "#d4d4d4"
-_LINK_COLOR = "#569cd6"
-_HR_COLOR = "#3c3c3c"
-_H_COLOR = "#569cd6"
+from .styles import blend_theme_color, get_host_palette_colors, use_native_host_theme
 
 _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,4}\s)|(^\s*[-*]\s+)|(^\s*\d+[.)]\s+)|```|`[^`]+`|\*\*|__|(?<!\w)\*(.+?)\*(?!\w)|(?<!\w)_(.+?)_(?!\w)|\[[^\]]+\]\([^)]+\)|^[-*_]{3,}\s*$",
     re.MULTILINE,
 )
 
-_INLINE_CODE_STYLE = (
-    f"background-color:{_CODE_BG}; color:{_CODE_FG}; "
-    f"padding:1px 4px; border-radius:3px; font-family:monospace; font-size:12px;"
-)
 
-_BLOCK_CODE_STYLE = (
-    f"background-color:{_BLOCK_BG}; color:{_BLOCK_FG}; "
-    f"border:1px solid {_CODE_BORDER}; border-radius:4px; "
-    f"padding:8px; font-family:monospace; font-size:12px; "
-    f"white-space:pre-wrap; word-break:break-all;"
-)
+def _theme_markdown_styles(source=None) -> dict[str, str]:
+    if use_native_host_theme():
+        return {
+            "inline_code_style": 'font-family:Consolas,"Courier New",monospace;',
+            "block_code_style": 'font-family:Consolas,"Courier New",monospace; white-space:pre-wrap;',
+            "link_style": "text-decoration: underline;",
+            "hr_style": "",
+            "heading_style": "font-weight:bold;",
+            "lang_tag_style": "font-size:10px;",
+        }
+
+    colors = get_host_palette_colors(source)
+    code_bg = blend_theme_color(colors["base"], colors["window"], 0.15)
+    inline_fg = blend_theme_color(colors["highlight"], colors["text"], 0.3)
+    border = blend_theme_color(colors["mid"], colors["window"], 0.35)
+    heading = blend_theme_color(colors["highlight"], colors["text"], 0.15)
+    return {
+        "inline_code_style": (
+            f"background-color:{code_bg}; color:{inline_fg}; "
+            "padding:1px 4px; border-radius:3px; font-family:monospace; font-size:12px;"
+        ),
+        "block_code_style": (
+            f"background-color:{colors['base']}; color:{colors['text']}; "
+            f"border:1px solid {border}; border-radius:4px; "
+            "padding:8px; font-family:monospace; font-size:12px; "
+            "white-space:pre-wrap; word-break:break-all;"
+        ),
+        "link_style": f"color:{colors['highlight']};",
+        "hr_style": f"border:1px solid {border};",
+        "heading_style": f"color:{heading}; font-weight:bold;",
+        "lang_tag_style": f"color:{blend_theme_color(colors['text'], colors['window'], 0.45)};font-size:10px;",
+    }
 
 
 def _has_markdown_syntax(text: str) -> bool:
@@ -52,10 +66,11 @@ def _has_markdown_syntax(text: str) -> bool:
     return bool(text and _MARKDOWN_HINT_RE.search(text))
 
 
-def md_to_html(text: str) -> str:
+def md_to_html(text: str, source=None) -> str:
     """Convert a Markdown string to Qt-compatible HTML."""
     if not text:
         return ""
+    theme = _theme_markdown_styles(source)
     if not _has_markdown_syntax(text):
         escaped = html.escape(text).replace("\n", "<br>")
         return re.sub(r"(<br>\s*){3,}", "<br><br>", escaped)
@@ -66,8 +81,12 @@ def md_to_html(text: str) -> str:
     def _stash_block(m: re.Match) -> str:
         lang = m.group(1) or ""
         code = html.escape(m.group(2).strip("\n"))
-        lang_tag = f'<span style="color:#808080;font-size:10px;">{html.escape(lang)}</span><br>' if lang else ""
-        block_html = f'<div style="{_BLOCK_CODE_STYLE}">{lang_tag}{code}</div>'
+        lang_tag = (
+            f'<span style="{theme["lang_tag_style"]}">{html.escape(lang)}</span><br>'
+            if lang
+            else ""
+        )
+        block_html = f'<div style="{theme["block_code_style"]}">{lang_tag}{code}</div>'
         blocks.append(block_html)
         return f"\x00BLOCK{len(blocks) - 1}\x00"
 
@@ -90,7 +109,8 @@ def md_to_html(text: str) -> str:
 
         # Horizontal rule
         if re.match(r"^[-*_]{3,}\s*$", stripped):
-            out_lines.append(f'<hr style="border:1px solid {_HR_COLOR};">')
+            hr_style = f' style="{theme["hr_style"]}"' if theme["hr_style"] else ""
+            out_lines.append(f"<hr{hr_style}>")
             i += 1
             continue
 
@@ -100,9 +120,9 @@ def md_to_html(text: str) -> str:
             level = len(hm.group(1))
             sizes = {1: 18, 2: 16, 3: 14, 4: 13}
             size = sizes.get(level, 13)
-            h_text = _inline(hm.group(2))
+            h_text = _inline(hm.group(2), theme)
             out_lines.append(
-                f'<div style="color:{_H_COLOR};font-weight:bold;font-size:{size}px;margin:6px 0 2px 0;">{h_text}</div>'
+                f'<div style="{theme["heading_style"]}font-size:{size}px;margin:6px 0 2px 0;">{h_text}</div>'
             )
             i += 1
             continue
@@ -112,7 +132,7 @@ def md_to_html(text: str) -> str:
             items: list[str] = []
             while i < len(lines) and re.match(r"^\s*[-*]\s+", lines[i]):
                 item_text = re.sub(r"^\s*[-*]\s+", "", lines[i])
-                items.append(f"<li>{_inline(item_text)}</li>")
+                items.append(f"<li>{_inline(item_text, theme)}</li>")
                 i += 1
             out_lines.append("<ul style='margin:2px 0 2px 16px;'>" + "".join(items) + "</ul>")
             continue
@@ -122,7 +142,7 @@ def md_to_html(text: str) -> str:
             items = []
             while i < len(lines) and re.match(r"^\s*\d+[.)]\s+", lines[i]):
                 item_text = re.sub(r"^\s*\d+[.)]\s+", "", lines[i])
-                items.append(f"<li>{_inline(item_text)}</li>")
+                items.append(f"<li>{_inline(item_text, theme)}</li>")
                 i += 1
             out_lines.append("<ol style='margin:2px 0 2px 16px;'>" + "".join(items) + "</ol>")
             continue
@@ -134,7 +154,7 @@ def md_to_html(text: str) -> str:
             continue
 
         # Regular text
-        out_lines.append(_inline(stripped))
+        out_lines.append(_inline(stripped, theme))
         i += 1
 
     result = "<br>".join(out_lines)
@@ -149,21 +169,22 @@ def md_to_html(text: str) -> str:
     return result
 
 
-def _inline(text: str) -> str:
+def _inline(text: str, theme: dict[str, str] | None = None) -> str:
     """Apply inline Markdown formatting to a line of text."""
+    theme = theme or _theme_markdown_styles()
     text = html.escape(text)
 
     # Stash inline code spans so bold/italic don't mangle their contents
     code_spans: list[str] = []
 
     def _stash_code(m: re.Match) -> str:
-        code_spans.append(f'<span style="{_INLINE_CODE_STYLE}">{m.group(1)}</span>')
+        code_spans.append(f'<span style="{theme["inline_code_style"]}">{m.group(1)}</span>')
         return f"\x01CODE{len(code_spans) - 1}\x01"
 
     text = re.sub(r"`([^`]+)`", _stash_code, text)
 
     # Now apply bold/italic/links on the text with code safely stashed
-    text = _inline_formatting(text)
+    text = _inline_formatting(text, theme["link_style"])
 
     # Restore code spans
     for idx, span_html in enumerate(code_spans):
@@ -172,8 +193,9 @@ def _inline(text: str) -> str:
     return text
 
 
-def _inline_formatting(text: str) -> str:
+def _inline_formatting(text: str, link_style: str | None = None) -> str:
     """Apply bold, italic, and link formatting."""
+    link_style = link_style or _theme_markdown_styles()["link_style"]
     # Bold: **text** or __text__
     text = re.sub(r"\*\*(.+?)\*\*", r"<b>\1</b>", text)
     text = re.sub(r"__(.+?)__", r"<b>\1</b>", text)
@@ -185,7 +207,7 @@ def _inline_formatting(text: str) -> str:
     # Links: [text](url)
     text = re.sub(
         r"\[([^\]]+)\]\(([^)]+)\)",
-        rf'<a style="color:{_LINK_COLOR};" href="\2">\1</a>',
+        rf'<a style="{link_style}" href="\2">\1</a>',
         text,
     )
 

--- a/rikugan/ui/message_widgets.py
+++ b/rikugan/ui/message_widgets.py
@@ -7,7 +7,6 @@ import re as _re
 from typing import ClassVar
 
 from .markdown import md_to_html
-from .styles import host_stylesheet
 from .qt_compat import (
     QFrame,
     QHBoxLayout,
@@ -21,6 +20,7 @@ from .qt_compat import (
     QWidget,
     qt_flags,
 )
+from .styles import host_stylesheet
 
 _THINKING_PHRASES = [
     "analyzing binary structure...",
@@ -313,7 +313,7 @@ class _ThinkingBlock(QFrame):
         )
         self._content.setStyleSheet(
             host_stylesheet(
-                f"color: #606078; font-size: 12px;",
+                "color: #606078; font-size: 12px;",
                 f"color: #606078; {_native_text_style(size=12, italic=True)}",
             )
         )

--- a/rikugan/ui/message_widgets.py
+++ b/rikugan/ui/message_widgets.py
@@ -7,7 +7,7 @@ import re as _re
 from typing import ClassVar
 
 from .markdown import md_to_html
-from .styles import blend_theme_color, get_host_palette_colors, host_stylesheet
+from .styles import host_stylesheet
 from .qt_compat import (
     QFrame,
     QHBoxLayout,
@@ -42,8 +42,45 @@ _THINKING_PHRASES = [
 ]
 
 
-def _theme_colors(source=None) -> dict[str, str]:
-    return get_host_palette_colors(source)
+_USER_ROLE = "#4ec9b0"
+_ASSISTANT_ROLE = "#569cd6"
+_BODY_TEXT = "#d4d4d4"
+_MUTED_TEXT = "#808080"
+_SUBTLE_TEXT = "#b0b0b0"
+_USER_BUBBLE_BG = "#0e639c"
+_USER_BUBBLE_BORDER = "#1177bb"
+_ASSISTANT_BUBBLE_BG = "#151515"
+_ASSISTANT_BUBBLE_BORDER = "#2c2c2c"
+_THINKING_SURFACE_BG = "#1e1e1e"
+_THINKING_BLOCK_BG = "#1a1a2e"
+_THINKING_BLOCK_BORDER = "#2a2a3e"
+_TOOL_BG = "#252526"
+_TOOL_BORDER = "#3c3c3c"
+
+
+def _frame_css(*, background: str, border: str | None = None, radius: int = 8) -> str:
+    border_css = f"border: 1px solid {border}; " if border else "border: none; "
+    return (
+        f"background-color: {background}; {border_css}"
+        f"border-radius: {radius}px;"
+    )
+
+
+def _bubble_css(
+    *,
+    background: str,
+    text_color: str,
+    border: str | None = None,
+    radius: int = 10,
+    padding: str = "8px 12px",
+    size: int = 13,
+) -> str:
+    border_css = f"border: 1px solid {border}; " if border else "border: none; "
+    return (
+        f"background-color: {background}; color: {text_color}; "
+        f"{border_css}border-radius: {radius}px; "
+        f"padding: {padding}; font-size: {size}px;"
+    )
 
 
 def _native_text_style(
@@ -65,25 +102,27 @@ def _native_text_style(
     return " ".join(parts)
 
 
-def _muted_text(colors: dict[str, str]) -> str:
-    return blend_theme_color(colors["text"], colors["window"], 0.45)
+def _muted_text(colors=None) -> str:
+    return _MUTED_TEXT
 
 
-def _subtle_text(colors: dict[str, str]) -> str:
-    return blend_theme_color(colors["text"], colors["window"], 0.6)
+def _subtle_text(colors=None) -> str:
+    return _SUBTLE_TEXT
 
 
 def _tool_frame_style(
+    source=None,
     accent: str | None = None,
     background: str | None = None,
     object_name: str = "message_tool",
 ) -> str:
-    colors = _theme_colors()
-    border = accent or blend_theme_color(colors["mid"], colors["window"], 0.35)
-    bg = background or colors["alt_base"]
-    return host_stylesheet(
-        (f"QFrame#{object_name} {{ background-color: {bg}; border: 1px solid {border}; border-radius: 6px; }}}}"),
-        f"QFrame#{object_name} {{ background: transparent; border: none; }}",
+    del source
+    border = accent or _TOOL_BORDER
+    bg = background or _TOOL_BG
+    return (
+        f"QFrame#{object_name} {{ "
+        f"{_frame_css(background=bg, border=border, radius=6)} "
+        "}"
     )
 
 
@@ -151,7 +190,6 @@ class UserMessageWidget(QFrame):
 
     def __init__(self, text: str, parent: QWidget = None):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("message_user")
 
         layout = QVBoxLayout(self)
@@ -160,8 +198,8 @@ class UserMessageWidget(QFrame):
         self._role_label = QLabel("You")
         self._role_label.setStyleSheet(
             host_stylesheet(
-                f"color: {colors['highlight']}; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: {_USER_ROLE}; font-weight: bold; font-size: 11px;",
+                f"color: {_USER_ROLE}; {_native_text_style(size=11, bold=True)}",
             )
         )
         layout.addWidget(self._role_label)
@@ -176,9 +214,13 @@ class UserMessageWidget(QFrame):
         )
         self._content.setStyleSheet(
             host_stylesheet(
-                f"background-color: {colors['highlight']}; color: {colors['highlight_text']}; "
+                f"background-color: {_USER_BUBBLE_BG}; color: #ffffff; "
                 "border-radius: 10px; padding: 8px 12px; font-size: 13px;",
-                _native_text_style(size=13),
+                _bubble_css(
+                    background=_USER_BUBBLE_BG,
+                    text_color="#ffffff",
+                    border=_USER_BUBBLE_BORDER,
+                ),
             )
         )
         self._content.setMinimumWidth(0)
@@ -233,12 +275,12 @@ class _ThinkingBlock(QFrame):
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("thinking_block")
         self.setStyleSheet(
             _tool_frame_style(
-                accent=blend_theme_color(colors["mid"], colors["window"], 0.25),
-                background=blend_theme_color(colors["base"], colors["window"], 0.4),
+                source=parent or self,
+                accent=_THINKING_BLOCK_BORDER,
+                background=_THINKING_BLOCK_BG,
                 object_name="thinking_block",
             )
         )
@@ -260,8 +302,8 @@ class _ThinkingBlock(QFrame):
         self._header_label = QLabel("Thinking")
         self._header_label.setStyleSheet(
             host_stylesheet(
-                f"color: {_muted_text(colors)}; font-size: 11px; font-style: italic;",
-                _native_text_style(size=11, italic=True),
+                f"color: {_MUTED_TEXT}; font-size: 11px; font-style: italic;",
+                f"color: {_MUTED_TEXT}; {_native_text_style(size=11, italic=True)}",
             )
         )
         header.addWidget(self._header_label, 1)
@@ -278,8 +320,8 @@ class _ThinkingBlock(QFrame):
         )
         self._content.setStyleSheet(
             host_stylesheet(
-                f"color: {_subtle_text(colors)}; font-size: 12px;",
-                _native_text_style(size=12, italic=True),
+                f"color: #606078; font-size: 12px;",
+                f"color: #606078; {_native_text_style(size=12, italic=True)}",
             )
         )
         self._content.hide()
@@ -313,7 +355,6 @@ class AssistantMessageWidget(QFrame):
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("message_assistant")
         self._full_text = ""
         self._pending_delta = 0
@@ -324,8 +365,8 @@ class AssistantMessageWidget(QFrame):
         self._role_label = QLabel("Rikugan")
         self._role_label.setStyleSheet(
             host_stylesheet(
-                f"color: {colors['highlight']}; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: {_ASSISTANT_ROLE}; font-weight: bold; font-size: 11px;",
+                f"color: {_ASSISTANT_ROLE}; {_native_text_style(size=11, bold=True)}",
             )
         )
         layout.addWidget(self._role_label)
@@ -346,9 +387,13 @@ class AssistantMessageWidget(QFrame):
         self._content.setOpenExternalLinks(True)
         self._content.setStyleSheet(
             host_stylesheet(
-                f"background-color: {colors['alt_base']}; color: {colors['text']}; "
+                f"background-color: {_ASSISTANT_BUBBLE_BG}; color: {_BODY_TEXT}; "
                 "border-radius: 10px; padding: 8px 12px; font-size: 13px;",
-                _native_text_style(size=13),
+                _bubble_css(
+                    background=_ASSISTANT_BUBBLE_BG,
+                    text_color=_BODY_TEXT,
+                    border=_ASSISTANT_BUBBLE_BORDER,
+                ),
             )
         )
         # Prevent the label from requesting more width than its parent
@@ -392,8 +437,14 @@ class ThinkingWidget(QFrame):
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("message_thinking")
+        self.setStyleSheet(
+            _tool_frame_style(
+                source=parent or self,
+                background=_THINKING_SURFACE_BG,
+                object_name="message_thinking",
+            )
+        )
         self._phrase_idx = random.randint(0, len(_THINKING_PHRASES) - 1)
         self._star_idx = 0
 
@@ -404,8 +455,8 @@ class ThinkingWidget(QFrame):
         self._star_label = QLabel(self._STAR_FRAMES[0])
         self._star_label.setStyleSheet(
             host_stylesheet(
-                f"color: {colors['highlight']}; font-size: 14px;",
-                _native_text_style(size=14),
+                "color: #dcdcaa; font-size: 14px;",
+                f"color: #dcdcaa; {_native_text_style(size=14)}",
             )
         )
         self._star_label.setFixedWidth(18)
@@ -414,8 +465,8 @@ class ThinkingWidget(QFrame):
         self._phrase_label = QLabel(_THINKING_PHRASES[self._phrase_idx])
         self._phrase_label.setStyleSheet(
             host_stylesheet(
-                f"color: {_muted_text(colors)}; font-style: italic; font-size: 12px;",
-                _native_text_style(size=12, italic=True),
+                "color: #808080; font-style: italic; font-size: 12px;",
+                f"color: #808080; {_native_text_style(size=12, italic=True)}",
             )
         )
         layout.addWidget(self._phrase_label, 1)
@@ -455,14 +506,11 @@ class QueuedMessageWidget(QFrame):
 
     def __init__(self, text: str, parent: QWidget = None):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("message_queued")
-        queued_bg = blend_theme_color(colors["highlight"], colors["window"], 0.88)
         self.setStyleSheet(
             host_stylesheet(
-                f"QFrame#message_queued {{ border: 1px dashed {colors['highlight']}; "
-                f"border-radius: 6px; background-color: {queued_bg}; }}",
-                "QFrame#message_queued { background: transparent; border: none; }",
+                "QFrame#message_queued { border: 1px dashed #007acc; border-radius: 6px; background: #1e1e2e; }",
+                "QFrame#message_queued { border: 1px dashed #007acc; border-radius: 6px; background: #1e1e2e; }",
             )
         )
 
@@ -474,8 +522,8 @@ class QueuedMessageWidget(QFrame):
         self._role_label = QLabel("You")
         self._role_label.setStyleSheet(
             host_stylesheet(
-                f"color: {colors['highlight']}; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: {_USER_ROLE}; font-weight: bold; font-size: 11px;",
+                f"color: {_USER_ROLE}; {_native_text_style(size=11, bold=True)}",
             )
         )
         content_layout.addWidget(self._role_label)
@@ -490,8 +538,8 @@ class QueuedMessageWidget(QFrame):
         )
         self._content.setStyleSheet(
             host_stylesheet(
-                f"color: {colors['text']}; font-size: 13px;",
-                _native_text_style(size=13),
+                f"color: {_BODY_TEXT}; font-size: 13px;",
+                f"color: {_BODY_TEXT}; {_native_text_style(size=13)}",
             )
         )
         content_layout.addWidget(self._content)
@@ -501,8 +549,8 @@ class QueuedMessageWidget(QFrame):
         self._badge = QLabel("[queued]")
         self._badge.setStyleSheet(
             host_stylesheet(
-                f"color: {_muted_text(colors)}; font-size: 10px; font-style: italic;",
-                _native_text_style(size=10, italic=True),
+                f"color: {_MUTED_TEXT}; font-size: 10px; font-style: italic;",
+                f"color: {_MUTED_TEXT}; {_native_text_style(size=10, italic=True)}",
             )
         )
         self._badge.setAlignment(Qt.AlignmentFlag.AlignTop)
@@ -514,13 +562,13 @@ class UserQuestionWidget(QFrame):
 
     def __init__(self, question: str, options: list | None = None, parent: QWidget = None):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self._option_selected_callback = None
         self.setObjectName("message_question")
         self.setStyleSheet(
             _tool_frame_style(
-                accent=colors["highlight"],
-                background=blend_theme_color(colors["highlight"], colors["window"], 0.9),
+                source=parent or self,
+                accent="#dcdcaa",
+                background="#2d2d1e",
                 object_name="message_question",
             )
         )
@@ -532,8 +580,8 @@ class UserQuestionWidget(QFrame):
         self._header = QLabel("Rikugan asks:")
         self._header.setStyleSheet(
             host_stylesheet(
-                f"color: {colors['highlight']}; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                "color: #dcdcaa; font-weight: bold; font-size: 11px;",
+                f"color: #dcdcaa; {_native_text_style(size=11, bold=True)}",
             )
         )
         layout.addWidget(self._header)
@@ -548,8 +596,8 @@ class UserQuestionWidget(QFrame):
         )
         self._q_label.setStyleSheet(
             host_stylesheet(
-                f"color: {colors['text']}; font-size: 13px;",
-                _native_text_style(size=13),
+                f"color: {_BODY_TEXT}; font-size: 13px;",
+                f"color: {_BODY_TEXT}; {_native_text_style(size=13)}",
             )
         )
         layout.addWidget(self._q_label)
@@ -560,17 +608,14 @@ class UserQuestionWidget(QFrame):
             btn_layout.setSpacing(8)
             for opt in options:
                 btn = QPushButton(opt)
-                btn.setStyleSheet(
-                    host_stylesheet(
-                        f"QPushButton {{ background: {colors['highlight']}; color: {colors['highlight_text']}; "
-                        f"border: 1px solid {blend_theme_color(colors['highlight'], colors['window'], 0.2)}; "
-                        "border-radius: 4px; padding: 4px 14px; font-size: 12px; }"
-                        f"QPushButton:hover {{ background: {blend_theme_color(colors['highlight'], colors['light'], 0.15)}; }}"
-                        f"QPushButton:pressed {{ background: {blend_theme_color(colors['highlight'], colors['dark'], 0.2)}; }}"
-                        f"QPushButton:disabled {{ color: {_muted_text(colors)}; "
-                        f"background: {blend_theme_color(colors['button'], colors['window'], 0.35)}; border-color: {colors['mid']}; }}",
-                    )
+                button_css = (
+                    "QPushButton { background: #2d4a6e; color: #9cdcfe; border: 1px solid #4a7ab5; "
+                    "border-radius: 4px; padding: 4px 14px; font-size: 12px; }"
+                    "QPushButton:hover { background: #3a5a8a; }"
+                    "QPushButton:pressed { background: #1a3a5e; }"
+                    "QPushButton:disabled { color: #808080; background: #1e2a3a; border-color: #444; }"
                 )
+                btn.setStyleSheet(host_stylesheet(button_css, button_css))
                 btn.clicked.connect(lambda checked, o=opt: self._on_option(o))
                 btn_layout.addWidget(btn)
             btn_layout.addStretch()
@@ -602,12 +647,12 @@ class ExplorationPhaseWidget(QFrame):
 
     def __init__(self, from_phase: str, to_phase: str, reason: str = "", parent: QWidget = None):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("message_tool")
         self.setStyleSheet(
             _tool_frame_style(
+                source=parent or self,
                 accent="#d7ba7d",
-                background=blend_theme_color("#d7ba7d", colors["window"], 0.9),
+                background="#2d2a1f",
             )
         )
 
@@ -620,7 +665,7 @@ class ExplorationPhaseWidget(QFrame):
         self._phase_label.setStyleSheet(
             host_stylesheet(
                 "color: #d7ba7d; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: #d7ba7d; {_native_text_style(size=11, bold=True)}",
             )
         )
         layout.addWidget(self._phase_label)
@@ -630,8 +675,8 @@ class ExplorationPhaseWidget(QFrame):
             self._reason_label.setWordWrap(True)
             self._reason_label.setStyleSheet(
                 host_stylesheet(
-                    f"color: {_subtle_text(colors)}; font-size: 11px;",
-                    _native_text_style(size=11),
+                    "color: #b0a070; font-size: 11px;",
+                    f"color: #b0a070; {_native_text_style(size=11)}",
                 )
             )
             layout.addWidget(self._reason_label, 1)
@@ -660,10 +705,9 @@ class ExplorationFindingWidget(QFrame):
         parent: QWidget = None,
     ):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("message_tool")
         color = self._CATEGORY_COLORS.get(category, "#808080")
-        self.setStyleSheet(_tool_frame_style(accent=color))
+        self.setStyleSheet(_tool_frame_style(source=parent or self, accent=color))
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(8, 4, 8, 4)
@@ -673,7 +717,7 @@ class ExplorationFindingWidget(QFrame):
         self._cat_label.setStyleSheet(
             host_stylesheet(
                 f"color: {color}; font-weight: bold; font-size: 10px;",
-                _native_text_style(size=10, bold=True),
+                f"color: {color}; {_native_text_style(size=10, bold=True)}",
             )
         )
         layout.addWidget(self._cat_label)
@@ -682,8 +726,8 @@ class ExplorationFindingWidget(QFrame):
             self._addr_label = QLabel(address)
             self._addr_label.setStyleSheet(
                 host_stylesheet(
-                    f"color: {_muted_text(colors)}; font-family: monospace; font-size: 10px;",
-                    _native_text_style(size=10, monospace=True),
+                    f"color: {_MUTED_TEXT}; font-family: monospace; font-size: 10px;",
+                    f"color: {_MUTED_TEXT}; {_native_text_style(size=10, monospace=True)}",
                 )
             )
             layout.addWidget(self._addr_label)
@@ -692,8 +736,8 @@ class ExplorationFindingWidget(QFrame):
         self._summary_label.setWordWrap(True)
         self._summary_label.setStyleSheet(
             host_stylesheet(
-                f"color: {colors['text']}; font-size: 11px;",
-                _native_text_style(size=11),
+                f"color: {_BODY_TEXT}; font-size: 11px;",
+                f"color: {_BODY_TEXT}; {_native_text_style(size=11)}",
             )
         )
         layout.addWidget(self._summary_label, 1)
@@ -703,7 +747,7 @@ class ExplorationFindingWidget(QFrame):
             rel_label.setStyleSheet(
                 host_stylesheet(
                     "color: #d7ba7d; font-size: 12px;",
-                    _native_text_style(size=12, bold=True),
+                    f"color: #d7ba7d; {_native_text_style(size=12, bold=True)}",
                 )
             )
             rel_label.setToolTip("High relevance")
@@ -723,10 +767,9 @@ class ResearchNoteWidget(QFrame):
         parent: QWidget = None,
     ):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("message_tool")
         accent = "#6a9955" if review_passed else "#d7ba7d"
-        self.setStyleSheet(_tool_frame_style(accent=accent))
+        self.setStyleSheet(_tool_frame_style(source=parent or self, accent=accent))
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 4, 8, 4)
@@ -739,7 +782,7 @@ class ResearchNoteWidget(QFrame):
         self._title_label.setStyleSheet(
             host_stylesheet(
                 f"color: {accent}; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: {accent}; {_native_text_style(size=11, bold=True)}",
             )
         )
         header.addWidget(self._title_label)
@@ -747,8 +790,8 @@ class ResearchNoteWidget(QFrame):
         self._genre_label = QLabel(f"#{genre}")
         self._genre_label.setStyleSheet(
             host_stylesheet(
-                f"color: {_muted_text(colors)}; font-size: 10px; font-style: italic;",
-                _native_text_style(size=10, italic=True),
+                f"color: {_MUTED_TEXT}; font-size: 10px; font-style: italic;",
+                f"color: {_MUTED_TEXT}; {_native_text_style(size=10, italic=True)}",
             )
         )
         header.addWidget(self._genre_label)
@@ -759,8 +802,8 @@ class ResearchNoteWidget(QFrame):
         self._path_label = QLabel(path)
         self._path_label.setStyleSheet(
             host_stylesheet(
-                f"color: {_subtle_text(colors)}; font-family: monospace; font-size: 10px;",
-                _native_text_style(size=10, monospace=True),
+                "color: #606060; font-family: monospace; font-size: 10px;",
+                f"color: #606060; {_native_text_style(size=10, monospace=True)}",
             )
         )
         layout.addWidget(self._path_label)
@@ -771,8 +814,8 @@ class ResearchNoteWidget(QFrame):
             self._preview_label.setWordWrap(True)
             self._preview_label.setStyleSheet(
                 host_stylesheet(
-                    f"color: {_subtle_text(colors)}; font-size: 11px;",
-                    _native_text_style(size=11),
+                    "color: #a0a0a0; font-size: 11px;",
+                    f"color: #a0a0a0; {_native_text_style(size=11)}",
                 )
             )
             layout.addWidget(self._preview_label)
@@ -795,13 +838,13 @@ class SubagentEventWidget(QFrame):
         parent: QWidget = None,
     ):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("message_tool")
         color = self._STATUS_COLORS.get(status, "#808080")
         self.setStyleSheet(
             _tool_frame_style(
+                source=parent or self,
                 accent=color,
-                background=blend_theme_color(color, colors["window"], 0.92),
+                background="#252530",
             )
         )
 
@@ -815,7 +858,7 @@ class SubagentEventWidget(QFrame):
         self._icon.setStyleSheet(
             host_stylesheet(
                 f"color: {color}; font-size: 14px;",
-                _native_text_style(size=14),
+                f"color: {color}; {_native_text_style(size=14)}",
             )
         )
         layout.addWidget(self._icon)
@@ -825,7 +868,7 @@ class SubagentEventWidget(QFrame):
         self._label.setStyleSheet(
             host_stylesheet(
                 f"color: {color}; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: {color}; {_native_text_style(size=11, bold=True)}",
             )
         )
         layout.addWidget(self._label)
@@ -835,8 +878,8 @@ class SubagentEventWidget(QFrame):
             self._detail.setWordWrap(True)
             self._detail.setStyleSheet(
                 host_stylesheet(
-                    f"color: {_subtle_text(colors)}; font-size: 11px;",
-                    _native_text_style(size=11),
+                    "color: #b0b0b0; font-size: 11px;",
+                    f"color: #b0b0b0; {_native_text_style(size=11)}",
                 )
             )
             layout.addWidget(self._detail, 1)
@@ -847,12 +890,11 @@ class ErrorMessageWidget(QFrame):
 
     def __init__(self, error_text: str, parent: QWidget = None):
         super().__init__(parent)
-        colors = _theme_colors(self)
         self.setObjectName("message_tool")
         self.setStyleSheet(
             _tool_frame_style(
+                source=parent or self,
                 accent="#f44747",
-                background=blend_theme_color("#f44747", colors["window"], 0.94),
             )
         )
 
@@ -863,7 +905,7 @@ class ErrorMessageWidget(QFrame):
         self._header.setStyleSheet(
             host_stylesheet(
                 "color: #f44747; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: #f44747; {_native_text_style(size=11, bold=True)}",
             )
         )
         layout.addWidget(self._header)
@@ -879,7 +921,7 @@ class ErrorMessageWidget(QFrame):
         self._content.setStyleSheet(
             host_stylesheet(
                 "color: #f44747; font-size: 12px;",
-                _native_text_style(size=12),
+                f"color: #f44747; {_native_text_style(size=12)}",
             )
         )
         self._content.setMinimumWidth(0)

--- a/rikugan/ui/message_widgets.py
+++ b/rikugan/ui/message_widgets.py
@@ -82,12 +82,10 @@ def _tool_frame_style(
     border = accent or blend_theme_color(colors["mid"], colors["window"], 0.35)
     bg = background or colors["alt_base"]
     return host_stylesheet(
-        (
-        f"QFrame#{object_name} {{ background-color: {bg}; border: 1px solid {border}; "
-        "border-radius: 6px; }}"
-        ),
+        (f"QFrame#{object_name} {{ background-color: {bg}; border: 1px solid {border}; border-radius: 6px; }}}}"),
         f"QFrame#{object_name} {{ background: transparent; border: none; }}",
     )
+
 
 # Re-export tool widgets so existing consumers that import from this module
 # continue to work without changes.

--- a/rikugan/ui/message_widgets.py
+++ b/rikugan/ui/message_widgets.py
@@ -60,10 +60,7 @@ _TOOL_BORDER = "#3c3c3c"
 
 def _frame_css(*, background: str, border: str | None = None, radius: int = 8) -> str:
     border_css = f"border: 1px solid {border}; " if border else "border: none; "
-    return (
-        f"background-color: {background}; {border_css}"
-        f"border-radius: {radius}px;"
-    )
+    return f"background-color: {background}; {border_css}border-radius: {radius}px;"
 
 
 def _bubble_css(
@@ -119,11 +116,7 @@ def _tool_frame_style(
     del source
     border = accent or _TOOL_BORDER
     bg = background or _TOOL_BG
-    return (
-        f"QFrame#{object_name} {{ "
-        f"{_frame_css(background=bg, border=border, radius=6)} "
-        "}"
-    )
+    return f"QFrame#{object_name} {{ {_frame_css(background=bg, border=border, radius=6)} }}"
 
 
 # Re-export tool widgets so existing consumers that import from this module

--- a/rikugan/ui/message_widgets.py
+++ b/rikugan/ui/message_widgets.py
@@ -7,6 +7,7 @@ import re as _re
 from typing import ClassVar
 
 from .markdown import md_to_html
+from .styles import blend_theme_color, get_host_palette_colors, host_stylesheet
 from .qt_compat import (
     QFrame,
     QHBoxLayout,
@@ -39,6 +40,54 @@ _THINKING_PHRASES = [
     "examining vtable references...",
     "decoding encoded values...",
 ]
+
+
+def _theme_colors(source=None) -> dict[str, str]:
+    return get_host_palette_colors(source)
+
+
+def _native_text_style(
+    *,
+    size: int | None = None,
+    bold: bool = False,
+    italic: bool = False,
+    monospace: bool = False,
+) -> str:
+    parts: list[str] = []
+    if size is not None:
+        parts.append(f"font-size: {size}px;")
+    if bold:
+        parts.append("font-weight: bold;")
+    if italic:
+        parts.append("font-style: italic;")
+    if monospace:
+        parts.append('font-family: Consolas, "Courier New", monospace;')
+    return " ".join(parts)
+
+
+def _muted_text(colors: dict[str, str]) -> str:
+    return blend_theme_color(colors["text"], colors["window"], 0.45)
+
+
+def _subtle_text(colors: dict[str, str]) -> str:
+    return blend_theme_color(colors["text"], colors["window"], 0.6)
+
+
+def _tool_frame_style(
+    accent: str | None = None,
+    background: str | None = None,
+    object_name: str = "message_tool",
+) -> str:
+    colors = _theme_colors()
+    border = accent or blend_theme_color(colors["mid"], colors["window"], 0.35)
+    bg = background or colors["alt_base"]
+    return host_stylesheet(
+        (
+        f"QFrame#{object_name} {{ background-color: {bg}; border: 1px solid {border}; "
+        "border-radius: 6px; }}"
+        ),
+        f"QFrame#{object_name} {{ background: transparent; border: none; }}",
+    )
 
 # Re-export tool widgets so existing consumers that import from this module
 # continue to work without changes.
@@ -104,13 +153,19 @@ class UserMessageWidget(QFrame):
 
     def __init__(self, text: str, parent: QWidget = None):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("message_user")
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 6, 8, 6)
 
         self._role_label = QLabel("You")
-        self._role_label.setStyleSheet("color: #4ec9b0; font-weight: bold; font-size: 11px;")
+        self._role_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {colors['highlight']}; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         layout.addWidget(self._role_label)
 
         self._content = QLabel(text)
@@ -121,7 +176,13 @@ class UserMessageWidget(QFrame):
                 Qt.TextInteractionFlag.TextSelectableByKeyboard,
             )
         )
-        self._content.setStyleSheet("color: #d4d4d4; font-size: 13px;")
+        self._content.setStyleSheet(
+            host_stylesheet(
+                f"background-color: {colors['highlight']}; color: {colors['highlight_text']}; "
+                "border-radius: 10px; padding: 8px 12px; font-size: 13px;",
+                _native_text_style(size=13),
+            )
+        )
         self._content.setMinimumWidth(0)
         self._content.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
         layout.addWidget(self._content)
@@ -174,8 +235,15 @@ class _ThinkingBlock(QFrame):
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("thinking_block")
-        self.setStyleSheet("#thinking_block { background: #1a1a2e; border: 1px solid #2a2a3e; border-radius: 6px; }")
+        self.setStyleSheet(
+            _tool_frame_style(
+                accent=blend_theme_color(colors["mid"], colors["window"], 0.25),
+                background=blend_theme_color(colors["base"], colors["window"], 0.4),
+                object_name="thinking_block",
+            )
+        )
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 4, 8, 4)
@@ -192,7 +260,12 @@ class _ThinkingBlock(QFrame):
         header.setSpacing(4)
         header.addWidget(self._toggle)
         self._header_label = QLabel("Thinking")
-        self._header_label.setStyleSheet("color: #707090; font-size: 11px; font-style: italic;")
+        self._header_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {_muted_text(colors)}; font-size: 11px; font-style: italic;",
+                _native_text_style(size=11, italic=True),
+            )
+        )
         header.addWidget(self._header_label, 1)
         layout.addLayout(header)
 
@@ -205,7 +278,12 @@ class _ThinkingBlock(QFrame):
                 Qt.TextInteractionFlag.TextSelectableByKeyboard,
             )
         )
-        self._content.setStyleSheet("color: #606078; font-size: 12px;")
+        self._content.setStyleSheet(
+            host_stylesheet(
+                f"color: {_subtle_text(colors)}; font-size: 12px;",
+                _native_text_style(size=12, italic=True),
+            )
+        )
         self._content.hide()
         layout.addWidget(self._content)
 
@@ -218,7 +296,7 @@ class _ThinkingBlock(QFrame):
         self._toggle.setText("\u25bc" if self._expanded else "\u25b6")
 
     def set_thinking(self, text: str, in_progress: bool = False) -> None:
-        self._content.setText(md_to_html(text))
+        self._content.setText(md_to_html(text, self))
         label = "Thinking\u2026" if in_progress else "Thinking"
         self._header_label.setText(label)
         self.show()
@@ -237,6 +315,7 @@ class AssistantMessageWidget(QFrame):
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("message_assistant")
         self._full_text = ""
         self._pending_delta = 0
@@ -245,7 +324,12 @@ class AssistantMessageWidget(QFrame):
         layout.setContentsMargins(8, 6, 8, 6)
 
         self._role_label = QLabel("Rikugan")
-        self._role_label.setStyleSheet("color: #569cd6; font-weight: bold; font-size: 11px;")
+        self._role_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {colors['highlight']}; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         layout.addWidget(self._role_label)
 
         self._thinking_block = _ThinkingBlock()
@@ -262,7 +346,13 @@ class AssistantMessageWidget(QFrame):
             )
         )
         self._content.setOpenExternalLinks(True)
-        self._content.setStyleSheet("color: #d4d4d4; font-size: 13px;")
+        self._content.setStyleSheet(
+            host_stylesheet(
+                f"background-color: {colors['alt_base']}; color: {colors['text']}; "
+                "border-radius: 10px; padding: 8px 12px; font-size: 13px;",
+                _native_text_style(size=13),
+            )
+        )
         # Prevent the label from requesting more width than its parent
         self._content.setMinimumWidth(0)
         self._content.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
@@ -275,7 +365,7 @@ class AssistantMessageWidget(QFrame):
             self._thinking_block.set_thinking(thinking, in_progress=in_progress)
         else:
             self._thinking_block.hide()
-        self._content.setText(md_to_html(visible))
+        self._content.setText(md_to_html(visible, self))
         self._pending_delta = 0
 
     def append_text(self, delta: str) -> None:
@@ -304,6 +394,7 @@ class ThinkingWidget(QFrame):
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("message_thinking")
         self._phrase_idx = random.randint(0, len(_THINKING_PHRASES) - 1)
         self._star_idx = 0
@@ -313,12 +404,22 @@ class ThinkingWidget(QFrame):
         layout.setSpacing(6)
 
         self._star_label = QLabel(self._STAR_FRAMES[0])
-        self._star_label.setStyleSheet("color: #dcdcaa; font-size: 14px;")
+        self._star_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {colors['highlight']}; font-size: 14px;",
+                _native_text_style(size=14),
+            )
+        )
         self._star_label.setFixedWidth(18)
         layout.addWidget(self._star_label)
 
         self._phrase_label = QLabel(_THINKING_PHRASES[self._phrase_idx])
-        self._phrase_label.setStyleSheet("color: #808080; font-style: italic; font-size: 12px;")
+        self._phrase_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {_muted_text(colors)}; font-style: italic; font-size: 12px;",
+                _native_text_style(size=12, italic=True),
+            )
+        )
         layout.addWidget(self._phrase_label, 1)
 
         self._stopped = False
@@ -356,9 +457,15 @@ class QueuedMessageWidget(QFrame):
 
     def __init__(self, text: str, parent: QWidget = None):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("message_queued")
+        queued_bg = blend_theme_color(colors["highlight"], colors["window"], 0.88)
         self.setStyleSheet(
-            "QFrame#message_queued { border: 1px dashed #007acc; border-radius: 6px; background: #1e1e2e; }"
+            host_stylesheet(
+                f"QFrame#message_queued {{ border: 1px dashed {colors['highlight']}; "
+                f"border-radius: 6px; background-color: {queued_bg}; }}",
+                "QFrame#message_queued { background: transparent; border: none; }",
+            )
         )
 
         layout = QHBoxLayout(self)
@@ -367,7 +474,12 @@ class QueuedMessageWidget(QFrame):
         content_layout = QVBoxLayout()
 
         self._role_label = QLabel("You")
-        self._role_label.setStyleSheet("color: #4ec9b0; font-weight: bold; font-size: 11px;")
+        self._role_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {colors['highlight']}; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         content_layout.addWidget(self._role_label)
 
         self._content = QLabel(text)
@@ -378,13 +490,23 @@ class QueuedMessageWidget(QFrame):
                 Qt.TextInteractionFlag.TextSelectableByKeyboard,
             )
         )
-        self._content.setStyleSheet("color: #d4d4d4; font-size: 13px;")
+        self._content.setStyleSheet(
+            host_stylesheet(
+                f"color: {colors['text']}; font-size: 13px;",
+                _native_text_style(size=13),
+            )
+        )
         content_layout.addWidget(self._content)
 
         layout.addLayout(content_layout, 1)
 
         self._badge = QLabel("[queued]")
-        self._badge.setStyleSheet("color: #808080; font-size: 10px; font-style: italic;")
+        self._badge.setStyleSheet(
+            host_stylesheet(
+                f"color: {_muted_text(colors)}; font-size: 10px; font-style: italic;",
+                _native_text_style(size=10, italic=True),
+            )
+        )
         self._badge.setAlignment(Qt.AlignmentFlag.AlignTop)
         layout.addWidget(self._badge)
 
@@ -394,10 +516,15 @@ class UserQuestionWidget(QFrame):
 
     def __init__(self, question: str, options: list | None = None, parent: QWidget = None):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self._option_selected_callback = None
         self.setObjectName("message_question")
         self.setStyleSheet(
-            "QFrame#message_question { border: 1px solid #dcdcaa; border-radius: 6px; background: #2d2d1e; }"
+            _tool_frame_style(
+                accent=colors["highlight"],
+                background=blend_theme_color(colors["highlight"], colors["window"], 0.9),
+                object_name="message_question",
+            )
         )
 
         layout = QVBoxLayout(self)
@@ -405,7 +532,12 @@ class UserQuestionWidget(QFrame):
         layout.setSpacing(6)
 
         self._header = QLabel("Rikugan asks:")
-        self._header.setStyleSheet("color: #dcdcaa; font-weight: bold; font-size: 11px;")
+        self._header.setStyleSheet(
+            host_stylesheet(
+                f"color: {colors['highlight']}; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         layout.addWidget(self._header)
 
         self._q_label = QLabel(question)
@@ -416,7 +548,12 @@ class UserQuestionWidget(QFrame):
                 Qt.TextInteractionFlag.TextSelectableByKeyboard,
             )
         )
-        self._q_label.setStyleSheet("color: #d4d4d4; font-size: 13px;")
+        self._q_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {colors['text']}; font-size: 13px;",
+                _native_text_style(size=13),
+            )
+        )
         layout.addWidget(self._q_label)
 
         if options:
@@ -426,11 +563,15 @@ class UserQuestionWidget(QFrame):
             for opt in options:
                 btn = QPushButton(opt)
                 btn.setStyleSheet(
-                    "QPushButton { background: #2d4a6e; color: #9cdcfe; border: 1px solid #4a7ab5; "
-                    "border-radius: 4px; padding: 4px 14px; font-size: 12px; }"
-                    "QPushButton:hover { background: #3a5a8a; }"
-                    "QPushButton:pressed { background: #1a3a5e; }"
-                    "QPushButton:disabled { color: #808080; background: #1e2a3a; border-color: #444; }"
+                    host_stylesheet(
+                        f"QPushButton {{ background: {colors['highlight']}; color: {colors['highlight_text']}; "
+                        f"border: 1px solid {blend_theme_color(colors['highlight'], colors['window'], 0.2)}; "
+                        "border-radius: 4px; padding: 4px 14px; font-size: 12px; }"
+                        f"QPushButton:hover {{ background: {blend_theme_color(colors['highlight'], colors['light'], 0.15)}; }}"
+                        f"QPushButton:pressed {{ background: {blend_theme_color(colors['highlight'], colors['dark'], 0.2)}; }}"
+                        f"QPushButton:disabled {{ color: {_muted_text(colors)}; "
+                        f"background: {blend_theme_color(colors['button'], colors['window'], 0.35)}; border-color: {colors['mid']}; }}",
+                    )
                 )
                 btn.clicked.connect(lambda checked, o=opt: self._on_option(o))
                 btn_layout.addWidget(btn)
@@ -463,8 +604,14 @@ class ExplorationPhaseWidget(QFrame):
 
     def __init__(self, from_phase: str, to_phase: str, reason: str = "", parent: QWidget = None):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("message_tool")
-        self.setStyleSheet("QFrame#message_tool { border-color: #d7ba7d; background: #2d2a1f; }")
+        self.setStyleSheet(
+            _tool_frame_style(
+                accent="#d7ba7d",
+                background=blend_theme_color("#d7ba7d", colors["window"], 0.9),
+            )
+        )
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(8, 6, 8, 6)
@@ -472,13 +619,23 @@ class ExplorationPhaseWidget(QFrame):
 
         icon = self._PHASE_ICONS.get(to_phase, "\u2192")
         self._phase_label = QLabel(f"{icon}  Phase: {to_phase.upper()}")
-        self._phase_label.setStyleSheet("color: #d7ba7d; font-weight: bold; font-size: 11px;")
+        self._phase_label.setStyleSheet(
+            host_stylesheet(
+                "color: #d7ba7d; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         layout.addWidget(self._phase_label)
 
         if reason:
             self._reason_label = QLabel(reason)
             self._reason_label.setWordWrap(True)
-            self._reason_label.setStyleSheet("color: #b0a070; font-size: 11px;")
+            self._reason_label.setStyleSheet(
+                host_stylesheet(
+                    f"color: {_subtle_text(colors)}; font-size: 11px;",
+                    _native_text_style(size=11),
+                )
+            )
             layout.addWidget(self._reason_label, 1)
 
 
@@ -505,31 +662,52 @@ class ExplorationFindingWidget(QFrame):
         parent: QWidget = None,
     ):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("message_tool")
         color = self._CATEGORY_COLORS.get(category, "#808080")
-        self.setStyleSheet(f"QFrame#message_tool {{ border-color: {color}; }}")
+        self.setStyleSheet(_tool_frame_style(accent=color))
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(8, 4, 8, 4)
         layout.setSpacing(6)
 
         self._cat_label = QLabel(f"[{category}]")
-        self._cat_label.setStyleSheet(f"color: {color}; font-weight: bold; font-size: 10px;")
+        self._cat_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {color}; font-weight: bold; font-size: 10px;",
+                _native_text_style(size=10, bold=True),
+            )
+        )
         layout.addWidget(self._cat_label)
 
         if address:
             self._addr_label = QLabel(address)
-            self._addr_label.setStyleSheet("color: #808080; font-family: monospace; font-size: 10px;")
+            self._addr_label.setStyleSheet(
+                host_stylesheet(
+                    f"color: {_muted_text(colors)}; font-family: monospace; font-size: 10px;",
+                    _native_text_style(size=10, monospace=True),
+                )
+            )
             layout.addWidget(self._addr_label)
 
         self._summary_label = QLabel(summary)
         self._summary_label.setWordWrap(True)
-        self._summary_label.setStyleSheet("color: #d4d4d4; font-size: 11px;")
+        self._summary_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {colors['text']}; font-size: 11px;",
+                _native_text_style(size=11),
+            )
+        )
         layout.addWidget(self._summary_label, 1)
 
         if relevance == "high":
             rel_label = QLabel("\u2605")
-            rel_label.setStyleSheet("color: #d7ba7d; font-size: 12px;")
+            rel_label.setStyleSheet(
+                host_stylesheet(
+                    "color: #d7ba7d; font-size: 12px;",
+                    _native_text_style(size=12, bold=True),
+                )
+            )
             rel_label.setToolTip("High relevance")
             layout.addWidget(rel_label)
 
@@ -547,9 +725,10 @@ class ResearchNoteWidget(QFrame):
         parent: QWidget = None,
     ):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("message_tool")
         accent = "#6a9955" if review_passed else "#d7ba7d"
-        self.setStyleSheet(f"QFrame#message_tool {{ border-color: {accent}; }}")
+        self.setStyleSheet(_tool_frame_style(accent=accent))
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 4, 8, 4)
@@ -559,25 +738,45 @@ class ResearchNoteWidget(QFrame):
         header = QHBoxLayout()
         icon = "\u2705" if review_passed else "\u270f"  # checkmark or pencil
         self._title_label = QLabel(f"{icon}  {title}")
-        self._title_label.setStyleSheet(f"color: {accent}; font-weight: bold; font-size: 11px;")
+        self._title_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {accent}; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         header.addWidget(self._title_label)
 
         self._genre_label = QLabel(f"#{genre}")
-        self._genre_label.setStyleSheet("color: #808080; font-size: 10px; font-style: italic;")
+        self._genre_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {_muted_text(colors)}; font-size: 10px; font-style: italic;",
+                _native_text_style(size=10, italic=True),
+            )
+        )
         header.addWidget(self._genre_label)
         header.addStretch()
         layout.addLayout(header)
 
         # Path
         self._path_label = QLabel(path)
-        self._path_label.setStyleSheet("color: #606060; font-family: monospace; font-size: 10px;")
+        self._path_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {_subtle_text(colors)}; font-family: monospace; font-size: 10px;",
+                _native_text_style(size=10, monospace=True),
+            )
+        )
         layout.addWidget(self._path_label)
 
         # Preview
         if preview:
             self._preview_label = QLabel(preview)
             self._preview_label.setWordWrap(True)
-            self._preview_label.setStyleSheet("color: #a0a0a0; font-size: 11px;")
+            self._preview_label.setStyleSheet(
+                host_stylesheet(
+                    f"color: {_subtle_text(colors)}; font-size: 11px;",
+                    _native_text_style(size=11),
+                )
+            )
             layout.addWidget(self._preview_label)
 
 
@@ -598,9 +797,15 @@ class SubagentEventWidget(QFrame):
         parent: QWidget = None,
     ):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("message_tool")
         color = self._STATUS_COLORS.get(status, "#808080")
-        self.setStyleSheet(f"QFrame#message_tool {{ border-color: {color}; background: #252530; }}")
+        self.setStyleSheet(
+            _tool_frame_style(
+                accent=color,
+                background=blend_theme_color(color, colors["window"], 0.92),
+            )
+        )
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(8, 6, 8, 6)
@@ -609,18 +814,33 @@ class SubagentEventWidget(QFrame):
         icon_map = {"spawned": "\u25b6", "completed": "\u2714", "failed": "\u2718"}
         icon = icon_map.get(status, "\u2022")
         self._icon = QLabel(icon)
-        self._icon.setStyleSheet(f"color: {color}; font-size: 14px;")
+        self._icon.setStyleSheet(
+            host_stylesheet(
+                f"color: {color}; font-size: 14px;",
+                _native_text_style(size=14),
+            )
+        )
         layout.addWidget(self._icon)
 
         label_text = f"Subagent \u201c{name}\u201d {status}"
         self._label = QLabel(label_text)
-        self._label.setStyleSheet(f"color: {color}; font-weight: bold; font-size: 11px;")
+        self._label.setStyleSheet(
+            host_stylesheet(
+                f"color: {color}; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         layout.addWidget(self._label)
 
         if detail:
             self._detail = QLabel(detail)
             self._detail.setWordWrap(True)
-            self._detail.setStyleSheet("color: #b0b0b0; font-size: 11px;")
+            self._detail.setStyleSheet(
+                host_stylesheet(
+                    f"color: {_subtle_text(colors)}; font-size: 11px;",
+                    _native_text_style(size=11),
+                )
+            )
             layout.addWidget(self._detail, 1)
 
 
@@ -629,14 +849,25 @@ class ErrorMessageWidget(QFrame):
 
     def __init__(self, error_text: str, parent: QWidget = None):
         super().__init__(parent)
+        colors = _theme_colors(self)
         self.setObjectName("message_tool")
-        self.setStyleSheet("QFrame#message_tool { border-color: #f44747; }")
+        self.setStyleSheet(
+            _tool_frame_style(
+                accent="#f44747",
+                background=blend_theme_color("#f44747", colors["window"], 0.94),
+            )
+        )
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 6, 8, 6)
 
         self._header = QLabel("Error")
-        self._header.setStyleSheet("color: #f44747; font-weight: bold; font-size: 11px;")
+        self._header.setStyleSheet(
+            host_stylesheet(
+                "color: #f44747; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         layout.addWidget(self._header)
 
         self._content = QLabel(error_text)
@@ -647,7 +878,12 @@ class ErrorMessageWidget(QFrame):
                 Qt.TextInteractionFlag.TextSelectableByKeyboard,
             )
         )
-        self._content.setStyleSheet("color: #f44747; font-size: 12px;")
+        self._content.setStyleSheet(
+            host_stylesheet(
+                "color: #f44747; font-size: 12px;",
+                _native_text_style(size=12),
+            )
+        )
         self._content.setMinimumWidth(0)
         self._content.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
         layout.addWidget(self._content)

--- a/rikugan/ui/panel_core.py
+++ b/rikugan/ui/panel_core.py
@@ -184,11 +184,13 @@ class _AddButtonTabBar(QTabBar):
         self._add_btn.setText("+")
         self._add_btn.setAutoRaise(True)
         self._add_btn.setFixedSize(20, 20)
-        self._add_btn.setStyleSheet(maybe_host_stylesheet(
-            "QToolButton { color: #d4d4d4; font-size: 14px; font-weight: bold; "
-            "border: none; background: transparent; }"
-            "QToolButton:hover { background: #3c3c3c; border-radius: 3px; }"
-        ))
+        self._add_btn.setStyleSheet(
+            maybe_host_stylesheet(
+                "QToolButton { color: #d4d4d4; font-size: 14px; font-weight: bold; "
+                "border: none; background: transparent; }"
+                "QToolButton:hover { background: #3c3c3c; border-radius: 3px; }"
+            )
+        )
         self._add_btn.clicked.connect(self._handle_add_tab)
 
     def set_add_tab_callback(self, callback: Callable[[], None] | None) -> None:
@@ -403,11 +405,13 @@ class RikuganPanelCore(QWidget):
         self._dependency_banner = QLabel()
         self._dependency_banner.setObjectName("dependency_banner")
         self._dependency_banner.setWordWrap(True)
-        self._dependency_banner.setStyleSheet(maybe_host_stylesheet(
-            "QLabel#dependency_banner {"
-            "background: #4b3900; color: #f5d98b; border-top: 1px solid #6b5000; "
-            "border-bottom: 1px solid #6b5000; padding: 6px 8px; font-size: 11px; }"
-        ))
+        self._dependency_banner.setStyleSheet(
+            maybe_host_stylesheet(
+                "QLabel#dependency_banner {"
+                "background: #4b3900; color: #f5d98b; border-top: 1px solid #6b5000; "
+                "border-bottom: 1px solid #6b5000; padding: 6px 8px; font-size: 11px; }"
+            )
+        )
         if self._dependency_warnings:
             self._dependency_banner.setText("Warnings: " + " ".join(self._dependency_warnings))
             layout.insertWidget(1, self._dependency_banner)
@@ -465,17 +469,19 @@ class RikuganPanelCore(QWidget):
         self._tab_bar.set_add_tab_callback(self._on_new_tab)
         self._tab_bar.set_export_tab_callback(self._on_export_tab)
         self._tab_bar.set_fork_tab_callback(self._on_fork_tab)
-        self._tab_widget.setStyleSheet(maybe_host_stylesheet(
-            "QTabWidget::pane { border: none; }"
-            "QTabBar { background: #1e1e1e; border: none; }"
-            "QTabBar::tab { background: #252526; color: #cccccc; padding: 2px 8px; "
-            "border: none; border-right: 1px solid #3c3c3c; "
-            "font-size: 11px; max-width: 140px; }"
-            "QTabBar::tab:selected { background: #1e1e1e; color: #ffffff; }"
-            "QTabBar::tab:hover { background: #2d2d2d; }"
-            "QTabBar::close-button { image: none; border: none; padding: 1px; }"
-            "QTabBar::close-button:hover { background: #c42b1c; border-radius: 2px; }"
-        ))
+        self._tab_widget.setStyleSheet(
+            maybe_host_stylesheet(
+                "QTabWidget::pane { border: none; }"
+                "QTabBar { background: #1e1e1e; border: none; }"
+                "QTabBar::tab { background: #252526; color: #cccccc; padding: 2px 8px; "
+                "border: none; border-right: 1px solid #3c3c3c; "
+                "font-size: 11px; max-width: 140px; }"
+                "QTabBar::tab:selected { background: #1e1e1e; color: #ffffff; }"
+                "QTabBar::tab:hover { background: #2d2d2d; }"
+                "QTabBar::close-button { image: none; border: none; padding: 1px; }"
+                "QTabBar::close-button:hover { background: #c42b1c; border-radius: 2px; }"
+            )
+        )
         self._tab_bar.setExpanding(False)
         self._tab_bar.setVisible(False)  # hidden until 2+ tabs
 
@@ -668,11 +674,13 @@ class RikuganPanelCore(QWidget):
         if session.subagent_logs:
             dlg = QDialog(self)
             dlg.setWindowTitle("Export Options")
-            dlg.setStyleSheet(maybe_host_stylesheet(
-                "QDialog { background: #1e1e1e; }"
-                "QLabel { color: #d4d4d4; font-size: 12px; }"
-                "QCheckBox { color: #d4d4d4; font-size: 12px; }"
-            ))
+            dlg.setStyleSheet(
+                maybe_host_stylesheet(
+                    "QDialog { background: #1e1e1e; }"
+                    "QLabel { color: #d4d4d4; font-size: 12px; }"
+                    "QCheckBox { color: #d4d4d4; font-size: 12px; }"
+                )
+            )
             layout = QVBoxLayout(dlg)
             cb = QCheckBox(f"Include subagent logs ({len(session.subagent_logs)} subagent runs)")
             cb.setChecked(True)
@@ -962,13 +970,15 @@ class RikuganPanelCore(QWidget):
         dlg.setWindowTitle("New Chat")
         dlg.setText("Start a new chat? Current conversation will be saved.")
         dlg.setInformativeText(f"Context usage: {context_pct}%")
-        dlg.setStyleSheet(maybe_host_stylesheet(
-            "QMessageBox { background: #1e1e1e; color: #d4d4d4; }"
-            "QLabel { color: #d4d4d4; font-size: 12px; }"
-            "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
-            "border-radius: 4px; padding: 6px 16px; font-size: 11px; min-width: 80px; }"
-            "QPushButton:hover { background: #3c3c3c; }"
-        ))
+        dlg.setStyleSheet(
+            maybe_host_stylesheet(
+                "QMessageBox { background: #1e1e1e; color: #d4d4d4; }"
+                "QLabel { color: #d4d4d4; font-size: 12px; }"
+                "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
+                "border-radius: 4px; padding: 6px 16px; font-size: 11px; min-width: 80px; }"
+                "QPushButton:hover { background: #3c3c3c; }"
+            )
+        )
         yes_btn = dlg.addButton("Yes", QMessageBox.ButtonRole.AcceptRole)
         clear_btn = dlg.addButton(
             f"Yes, clear context ({context_pct}% used)",

--- a/rikugan/ui/panel_core.py
+++ b/rikugan/ui/panel_core.py
@@ -12,9 +12,10 @@ from typing import Any
 from ..agent.mutation import MutationRecord
 from ..agent.turn import TurnEvent, TurnEventType
 from ..core.config import RikuganConfig
-from ..core.logging import log_debug, log_error, log_info
+from ..core.logging import log_debug, log_error, log_info, log_warning
 from ..core.types import Role
 from ..providers.auth_cache import resolve_auth_cached
+from ..providers.registry import ProviderRegistry
 from .chat_view import ChatView
 from .context_bar import ContextBar
 from .input_area import InputArea
@@ -25,6 +26,7 @@ from .qt_compat import (
     QDialogButtonBox,
     QFileDialog,
     QHBoxLayout,
+    QLabel,
     QMenu,
     QMessageBox,
     QPushButton,
@@ -40,7 +42,12 @@ from .qt_compat import (
     qt_flags,
     qt_run,
 )
-from .styles import DARK_THEME
+from .styles import (
+    build_small_button_stylesheet,
+    build_theme_stylesheet,
+    maybe_host_stylesheet,
+    use_native_host_theme,
+)
 from .tool_widgets import _SharedSpinnerTimer
 from .tools_panel import ToolsPanel
 
@@ -177,11 +184,11 @@ class _AddButtonTabBar(QTabBar):
         self._add_btn.setText("+")
         self._add_btn.setAutoRaise(True)
         self._add_btn.setFixedSize(20, 20)
-        self._add_btn.setStyleSheet(
+        self._add_btn.setStyleSheet(maybe_host_stylesheet(
             "QToolButton { color: #d4d4d4; font-size: 14px; font-weight: bold; "
             "border: none; background: transparent; }"
             "QToolButton:hover { background: #3c3c3c; border-radius: 3px; }"
-        )
+        ))
         self._add_btn.clicked.connect(self._handle_add_tab)
 
     def set_add_tab_callback(self, callback: Callable[[], None] | None) -> None:
@@ -244,9 +251,13 @@ class RikuganPanelCore(QWidget):
     ):
         super().__init__(parent)
         self._config = RikuganConfig.load_or_create()
+        self._use_native_host_theme = use_native_host_theme()
+        self._dependency_warnings = ProviderRegistry().dependency_warnings()
         log_debug(
             f"Config loaded: provider={self._config.provider.name} model={self._config.provider.model}",
         )
+        for warning in self._dependency_warnings:
+            log_warning(f"Dependency warning: {warning}")
         if self._config.has_encrypted_keys():
             self._prompt_decryption_password()
         self._ctrl = controller_factory(self._config)
@@ -364,8 +375,8 @@ class RikuganPanelCore(QWidget):
     )
 
     def _build_ui(self) -> None:
-        self.setStyleSheet(DARK_THEME)
         self.setObjectName("rikugan_panel")
+        self.setStyleSheet(build_theme_stylesheet(self))
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -375,7 +386,7 @@ class RikuganPanelCore(QWidget):
         # Hosts may optionally provide tools in a separate form.
         self._mode_bar = QTabBar()
         self._mode_bar.setObjectName("mode_bar")
-        self._mode_bar.setStyleSheet(self._MODE_BAR_STYLE)
+        self._mode_bar.setStyleSheet("" if self._use_native_host_theme else self._MODE_BAR_STYLE)
         self._mode_bar.setExpanding(False)
         self._mode_bar.setDrawBase(False)
         self._mode_bar.addTab("Chat")
@@ -388,6 +399,20 @@ class RikuganPanelCore(QWidget):
         # Stacked content: page 0 = chat, page 1 = tools
         self._mode_stack = QStackedWidget()
         layout.addWidget(self._mode_stack, 1)
+
+        self._dependency_banner = QLabel()
+        self._dependency_banner.setObjectName("dependency_banner")
+        self._dependency_banner.setWordWrap(True)
+        self._dependency_banner.setStyleSheet(maybe_host_stylesheet(
+            "QLabel#dependency_banner {"
+            "background: #4b3900; color: #f5d98b; border-top: 1px solid #6b5000; "
+            "border-bottom: 1px solid #6b5000; padding: 6px 8px; font-size: 11px; }"
+        ))
+        if self._dependency_warnings:
+            self._dependency_banner.setText("Warnings: " + " ".join(self._dependency_warnings))
+            layout.insertWidget(1, self._dependency_banner)
+        else:
+            self._dependency_banner.hide()
 
         # --- Page 0: Chat ---
         chat_page = QWidget()
@@ -440,7 +465,7 @@ class RikuganPanelCore(QWidget):
         self._tab_bar.set_add_tab_callback(self._on_new_tab)
         self._tab_bar.set_export_tab_callback(self._on_export_tab)
         self._tab_bar.set_fork_tab_callback(self._on_fork_tab)
-        self._tab_widget.setStyleSheet(
+        self._tab_widget.setStyleSheet(maybe_host_stylesheet(
             "QTabWidget::pane { border: none; }"
             "QTabBar { background: #1e1e1e; border: none; }"
             "QTabBar::tab { background: #252526; color: #cccccc; padding: 2px 8px; "
@@ -450,7 +475,7 @@ class RikuganPanelCore(QWidget):
             "QTabBar::tab:hover { background: #2d2d2d; }"
             "QTabBar::close-button { image: none; border: none; padding: 1px; }"
             "QTabBar::close-button:hover { background: #c42b1c; border-radius: 2px; }"
-        )
+        ))
         self._tab_bar.setExpanding(False)
         self._tab_bar.setVisible(False)  # hidden until 2+ tabs
 
@@ -458,7 +483,7 @@ class RikuganPanelCore(QWidget):
         """Create the horizontal splitter (chat | mutation log) and add to layout."""
         self._main_splitter = QSplitter(Qt.Orientation.Horizontal)
         self._main_splitter.setHandleWidth(1)
-        self._main_splitter.setStyleSheet("QSplitter::handle { background: #3c3c3c; }")
+        self._main_splitter.setStyleSheet(maybe_host_stylesheet("QSplitter::handle { background: #3c3c3c; }"))
         self._main_splitter.addWidget(self._tab_widget)
 
         self._mutation_panel = MutationLogPanel()
@@ -477,7 +502,7 @@ class RikuganPanelCore(QWidget):
         input_layout = QHBoxLayout(self._input_container)
         input_layout.setContentsMargins(8, 4, 8, 4)
 
-        self._input_area = InputArea()
+        self._input_area = InputArea(self._input_container)
         self._input_area.set_submit_callback(self._on_submit)
         self._input_area.set_cancel_callback(self._on_cancel)
         self._input_area.set_skill_slugs(self._ctrl.skill_slugs)
@@ -494,34 +519,34 @@ class RikuganPanelCore(QWidget):
         self._send_btn = QPushButton("Send")
         self._send_btn.setObjectName("send_button")
         self._send_btn.setFixedWidth(64)
-        self._send_btn.setStyleSheet(_SMALL_BTN_STYLE)
+        self._send_btn.setStyleSheet(maybe_host_stylesheet(_SMALL_BTN_STYLE))
         self._send_btn.clicked.connect(self._on_send_clicked)
         btn_layout.addWidget(self._send_btn)
         self._cancel_btn = QPushButton("Stop")
         self._cancel_btn.setObjectName("cancel_button")
         self._cancel_btn.setFixedWidth(64)
-        self._cancel_btn.setStyleSheet(_CANCEL_BTN_STYLE)
+        self._cancel_btn.setStyleSheet(maybe_host_stylesheet(_CANCEL_BTN_STYLE))
         self._cancel_btn.setVisible(False)
         self._cancel_btn.clicked.connect(self._on_cancel)
         btn_layout.addWidget(self._cancel_btn)
         self._new_btn = QPushButton("New")
         self._new_btn.setFixedWidth(64)
-        self._new_btn.setStyleSheet(_SMALL_BTN_STYLE)
+        self._new_btn.setStyleSheet(maybe_host_stylesheet(_SMALL_BTN_STYLE))
         self._new_btn.clicked.connect(self._on_new_tab)
         btn_layout.addWidget(self._new_btn)
         self._export_btn = QPushButton("Export")
         self._export_btn.setFixedWidth(64)
-        self._export_btn.setStyleSheet(_SMALL_BTN_STYLE)
+        self._export_btn.setStyleSheet(maybe_host_stylesheet(_SMALL_BTN_STYLE))
         self._export_btn.clicked.connect(self._on_export_current)
         btn_layout.addWidget(self._export_btn)
         self._settings_btn = QPushButton("Settings")
         self._settings_btn.setFixedWidth(64)
-        self._settings_btn.setStyleSheet(_SMALL_BTN_STYLE)
+        self._settings_btn.setStyleSheet(maybe_host_stylesheet(_SMALL_BTN_STYLE))
         self._settings_btn.clicked.connect(self._on_settings)
         btn_layout.addWidget(self._settings_btn)
         self._mutations_btn = QPushButton("Mutations")
         self._mutations_btn.setFixedWidth(64)
-        self._mutations_btn.setStyleSheet(_SMALL_BTN_STYLE)
+        self._mutations_btn.setStyleSheet(maybe_host_stylesheet(_SMALL_BTN_STYLE))
         self._mutations_btn.setCheckable(True)
         self._mutations_btn.clicked.connect(self._on_toggle_mutation_log)
         self._mutations_btn.setVisible(False)  # shown when first mutation is recorded
@@ -529,10 +554,21 @@ class RikuganPanelCore(QWidget):
 
         self._tools_btn = QPushButton("Tools")
         self._tools_btn.setFixedWidth(64)
-        self._tools_btn.setStyleSheet(_SMALL_BTN_STYLE)
+        self._tools_btn.setStyleSheet(maybe_host_stylesheet(_SMALL_BTN_STYLE))
         self._tools_btn.setCheckable(True)
         self._tools_btn.clicked.connect(self._on_toggle_tools)
         btn_layout.addWidget(self._tools_btn)
+
+        if self._use_native_host_theme:
+            default_btn_style = build_small_button_stylesheet(self)
+            danger_btn_style = build_small_button_stylesheet(self, danger=True)
+            self._send_btn.setStyleSheet(default_btn_style)
+            self._cancel_btn.setStyleSheet(danger_btn_style)
+            self._new_btn.setStyleSheet(default_btn_style)
+            self._export_btn.setStyleSheet(default_btn_style)
+            self._settings_btn.setStyleSheet(default_btn_style)
+            self._mutations_btn.setStyleSheet(default_btn_style)
+            self._tools_btn.setStyleSheet(default_btn_style)
 
         btn_layout.addStretch()
         return btn_layout
@@ -632,11 +668,11 @@ class RikuganPanelCore(QWidget):
         if session.subagent_logs:
             dlg = QDialog(self)
             dlg.setWindowTitle("Export Options")
-            dlg.setStyleSheet(
+            dlg.setStyleSheet(maybe_host_stylesheet(
                 "QDialog { background: #1e1e1e; }"
                 "QLabel { color: #d4d4d4; font-size: 12px; }"
                 "QCheckBox { color: #d4d4d4; font-size: 12px; }"
-            )
+            ))
             layout = QVBoxLayout(dlg)
             cb = QCheckBox(f"Include subagent logs ({len(session.subagent_logs)} subagent runs)")
             cb.setChecked(True)
@@ -926,13 +962,13 @@ class RikuganPanelCore(QWidget):
         dlg.setWindowTitle("New Chat")
         dlg.setText("Start a new chat? Current conversation will be saved.")
         dlg.setInformativeText(f"Context usage: {context_pct}%")
-        dlg.setStyleSheet(
+        dlg.setStyleSheet(maybe_host_stylesheet(
             "QMessageBox { background: #1e1e1e; color: #d4d4d4; }"
             "QLabel { color: #d4d4d4; font-size: 12px; }"
             "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
             "border-radius: 4px; padding: 6px 16px; font-size: 11px; min-width: 80px; }"
             "QPushButton:hover { background: #3c3c3c; }"
-        )
+        ))
         yes_btn = dlg.addButton("Yes", QMessageBox.ButtonRole.AcceptRole)
         clear_btn = dlg.addButton(
             f"Yes, clear context ({context_pct}% used)",

--- a/rikugan/ui/plan_view.py
+++ b/rikugan/ui/plan_view.py
@@ -90,20 +90,24 @@ class PlanView(QFrame):
         btn_layout = QHBoxLayout()
 
         self._approve_btn = QPushButton("Approve & Execute")
-        self._approve_btn.setStyleSheet(maybe_host_stylesheet(
-            "QPushButton { background: #2ea043; color: white; border: none; "
-            "border-radius: 6px; padding: 6px 16px; font-weight: bold; }"
-            "QPushButton:hover { background: #3fb950; }"
-        ))
+        self._approve_btn.setStyleSheet(
+            maybe_host_stylesheet(
+                "QPushButton { background: #2ea043; color: white; border: none; "
+                "border-radius: 6px; padding: 6px 16px; font-weight: bold; }"
+                "QPushButton:hover { background: #3fb950; }"
+            )
+        )
         self._approve_btn.clicked.connect(self._fire_approved)
         btn_layout.addWidget(self._approve_btn)
 
         self._reject_btn = QPushButton("Reject")
-        self._reject_btn.setStyleSheet(maybe_host_stylesheet(
-            "QPushButton { background: #c72e2e; color: white; border: none; "
-            "border-radius: 6px; padding: 6px 16px; font-weight: bold; }"
-            "QPushButton:hover { background: #d73a49; }"
-        ))
+        self._reject_btn.setStyleSheet(
+            maybe_host_stylesheet(
+                "QPushButton { background: #c72e2e; color: white; border: none; "
+                "border-radius: 6px; padding: 6px 16px; font-weight: bold; }"
+                "QPushButton:hover { background: #d73a49; }"
+            )
+        )
         self._reject_btn.clicked.connect(self._fire_rejected)
         btn_layout.addWidget(self._reject_btn)
 

--- a/rikugan/ui/plan_view.py
+++ b/rikugan/ui/plan_view.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QFrame,
     QHBoxLayout,
@@ -11,6 +10,7 @@ from .qt_compat import (
     QVBoxLayout,
     QWidget,
 )
+from .styles import maybe_host_stylesheet
 
 
 class PlanStepWidget(QFrame):

--- a/rikugan/ui/plan_view.py
+++ b/rikugan/ui/plan_view.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QFrame,
     QHBoxLayout,
@@ -26,12 +27,12 @@ class PlanStepWidget(QFrame):
 
         self._status_label = QLabel("○")
         self._status_label.setFixedWidth(20)
-        self._status_label.setStyleSheet("color: #808080; font-size: 14px;")
+        self._status_label.setStyleSheet(maybe_host_stylesheet("color: #808080; font-size: 14px;"))
         layout.addWidget(self._status_label)
 
         self._step_label = QLabel(f"{index + 1}. {text}")
         self._step_label.setWordWrap(True)
-        self._step_label.setStyleSheet("color: #d4d4d4; font-size: 12px;")
+        self._step_label.setStyleSheet(maybe_host_stylesheet("color: #d4d4d4; font-size: 12px;"))
         layout.addWidget(self._step_label, 1)
 
     def set_status(self, status: str) -> None:
@@ -39,21 +40,21 @@ class PlanStepWidget(QFrame):
         if status == "active":
             self.setObjectName("plan_step_active")
             self._status_label.setText("▶")
-            self._status_label.setStyleSheet("color: #007acc; font-size: 14px;")
+            self._status_label.setStyleSheet(maybe_host_stylesheet("color: #007acc; font-size: 14px;"))
         elif status == "done":
             self.setObjectName("plan_step_done")
             self._status_label.setText("✓")
-            self._status_label.setStyleSheet("color: #4ec9b0; font-size: 14px;")
+            self._status_label.setStyleSheet(maybe_host_stylesheet("color: #4ec9b0; font-size: 14px;"))
         elif status == "error":
             self._status_label.setText("✗")
-            self._status_label.setStyleSheet("color: #f44747; font-size: 14px;")
+            self._status_label.setStyleSheet(maybe_host_stylesheet("color: #f44747; font-size: 14px;"))
         elif status == "skipped":
             self._status_label.setText("−")
-            self._status_label.setStyleSheet("color: #808080; font-size: 14px;")
+            self._status_label.setStyleSheet(maybe_host_stylesheet("color: #808080; font-size: 14px;"))
         else:
             self.setObjectName("plan_step")
             self._status_label.setText("○")
-            self._status_label.setStyleSheet("color: #808080; font-size: 14px;")
+            self._status_label.setStyleSheet(maybe_host_stylesheet("color: #808080; font-size: 14px;"))
         self.style().unpolish(self)
         self.style().polish(self)
 
@@ -78,7 +79,7 @@ class PlanView(QFrame):
 
         # Header
         self._header = QLabel("Plan")
-        self._header.setStyleSheet("color: #569cd6; font-weight: bold; font-size: 13px;")
+        self._header.setStyleSheet(maybe_host_stylesheet("color: #569cd6; font-weight: bold; font-size: 13px;"))
         layout.addWidget(self._header)
 
         # Steps container
@@ -89,20 +90,20 @@ class PlanView(QFrame):
         btn_layout = QHBoxLayout()
 
         self._approve_btn = QPushButton("Approve & Execute")
-        self._approve_btn.setStyleSheet(
+        self._approve_btn.setStyleSheet(maybe_host_stylesheet(
             "QPushButton { background: #2ea043; color: white; border: none; "
             "border-radius: 6px; padding: 6px 16px; font-weight: bold; }"
             "QPushButton:hover { background: #3fb950; }"
-        )
+        ))
         self._approve_btn.clicked.connect(self._fire_approved)
         btn_layout.addWidget(self._approve_btn)
 
         self._reject_btn = QPushButton("Reject")
-        self._reject_btn.setStyleSheet(
+        self._reject_btn.setStyleSheet(maybe_host_stylesheet(
             "QPushButton { background: #c72e2e; color: white; border: none; "
             "border-radius: 6px; padding: 6px 16px; font-weight: bold; }"
             "QPushButton:hover { background: #d73a49; }"
-        )
+        ))
         self._reject_btn.clicked.connect(self._fire_rejected)
         btn_layout.addWidget(self._reject_btn)
 

--- a/rikugan/ui/qt_compat.py
+++ b/rikugan/ui/qt_compat.py
@@ -60,7 +60,7 @@ QT_BINDING: str = _detect_binding()
 # ---------------------------------------------------------------------------
 
 if QT_BINDING == "PySide6":
-    from PySide6.QtCore import QObject, QEvent, Qt, QTimer, Signal
+    from PySide6.QtCore import QEvent, QObject, Qt, QTimer, Signal
     from PySide6.QtGui import (
         QColor,
         QFont,
@@ -110,7 +110,7 @@ if QT_BINDING == "PySide6":
         QWidget,
     )
 else:
-    from PyQt5.QtCore import QObject, QEvent, Qt, QTimer  # noqa: F401
+    from PyQt5.QtCore import QEvent, QObject, Qt, QTimer  # noqa: F401
     from PyQt5.QtCore import pyqtSignal as Signal  # noqa: F401
     from PyQt5.QtGui import (  # noqa: F401
         QColor,

--- a/rikugan/ui/qt_compat.py
+++ b/rikugan/ui/qt_compat.py
@@ -60,11 +60,12 @@ QT_BINDING: str = _detect_binding()
 # ---------------------------------------------------------------------------
 
 if QT_BINDING == "PySide6":
-    from PySide6.QtCore import QObject, Qt, QTimer, Signal
+    from PySide6.QtCore import QObject, QEvent, Qt, QTimer, Signal
     from PySide6.QtGui import (
         QColor,
         QFont,
         QIntValidator,
+        QPalette,
         QSyntaxHighlighter,
         QTextCharFormat,
     )
@@ -109,12 +110,13 @@ if QT_BINDING == "PySide6":
         QWidget,
     )
 else:
-    from PyQt5.QtCore import QObject, Qt, QTimer  # noqa: F401
+    from PyQt5.QtCore import QObject, QEvent, Qt, QTimer  # noqa: F401
     from PyQt5.QtCore import pyqtSignal as Signal  # noqa: F401
     from PyQt5.QtGui import (  # noqa: F401
         QColor,
         QFont,
         QIntValidator,
+        QPalette,
         QSyntaxHighlighter,
         QTextCharFormat,
     )

--- a/rikugan/ui/settings_dialog.py
+++ b/rikugan/ui/settings_dialog.py
@@ -12,7 +12,6 @@ from ..core.types import ModelInfo
 from ..providers.auth_cache import resolve_auth_cached
 from ..providers.ollama_provider import DEFAULT_OLLAMA_URL
 from ..providers.registry import ProviderRegistry
-from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QApplication,
     QCheckBox,
@@ -33,6 +32,7 @@ from .qt_compat import (
     QVBoxLayout,
     QWidget,
 )
+from .styles import maybe_host_stylesheet
 
 _DEFAULT_MINIMAX_URL = "https://api.minimax.io/anthropic"
 _CUSTOM_PROVIDER_URL_PLACEHOLDER = "https://api.example.com/v1"

--- a/rikugan/ui/settings_dialog.py
+++ b/rikugan/ui/settings_dialog.py
@@ -349,11 +349,13 @@ class SettingsDialog(QDialog):
 
         self._fetch_btn = QPushButton("Refresh")
         self._fetch_btn.setFixedWidth(70)
-        self._fetch_btn.setStyleSheet(maybe_host_stylesheet(
-            "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
-            "border-radius: 4px; padding: 4px; font-size: 11px; }"
-            "QPushButton:hover { background: #3c3c3c; }"
-        ))
+        self._fetch_btn.setStyleSheet(
+            maybe_host_stylesheet(
+                "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
+                "border-radius: 4px; padding: 4px; font-size: 11px; }"
+                "QPushButton:hover { background: #3c3c3c; }"
+            )
+        )
         self._fetch_btn.clicked.connect(self._fetch_models)
         model_layout.addWidget(self._fetch_btn)
 

--- a/rikugan/ui/settings_dialog.py
+++ b/rikugan/ui/settings_dialog.py
@@ -12,6 +12,7 @@ from ..core.types import ModelInfo
 from ..providers.auth_cache import resolve_auth_cached
 from ..providers.ollama_provider import DEFAULT_OLLAMA_URL
 from ..providers.registry import ProviderRegistry
+from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QApplication,
     QCheckBox,
@@ -139,7 +140,7 @@ class _AddProviderDialog(QDialog):
         layout.addLayout(form)
 
         self._error_label = QLabel()
-        self._error_label.setStyleSheet("color: #f44747; font-size: 11px;")
+        self._error_label.setStyleSheet(maybe_host_stylesheet("color: #f44747; font-size: 11px;"))
         self._error_label.hide()
         layout.addWidget(self._error_label)
 
@@ -265,6 +266,16 @@ class SettingsDialog(QDialog):
         provider_group = QGroupBox("LLM Provider")
         provider_form = QFormLayout(provider_group)
 
+        warnings = self._registry.dependency_warnings()
+        self._dependency_label = QLabel()
+        self._dependency_label.setWordWrap(True)
+        self._dependency_label.setStyleSheet(maybe_host_stylesheet("color: #f5d98b; font-size: 11px;"))
+        if warnings:
+            self._dependency_label.setText("Warnings: " + " ".join(warnings))
+            provider_form.addRow(self._dependency_label)
+        else:
+            self._dependency_label.hide()
+
         provider_form.addRow("Provider:", self._build_provider_row())
 
         # API key — only show explicit user keys, NOT auto-resolved OAuth tokens
@@ -298,7 +309,7 @@ class SettingsDialog(QDialog):
 
     def _build_provider_row(self) -> QHBoxLayout:
         """Build the provider combo + add/remove buttons row."""
-        btn_style = (
+        btn_style = maybe_host_stylesheet(
             "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
             "border-radius: 4px; font-size: 13px; font-weight: bold; }"
             "QPushButton:hover { background: #3c3c3c; }"
@@ -338,16 +349,16 @@ class SettingsDialog(QDialog):
 
         self._fetch_btn = QPushButton("Refresh")
         self._fetch_btn.setFixedWidth(70)
-        self._fetch_btn.setStyleSheet(
+        self._fetch_btn.setStyleSheet(maybe_host_stylesheet(
             "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
             "border-radius: 4px; padding: 4px; font-size: 11px; }"
             "QPushButton:hover { background: #3c3c3c; }"
-        )
+        ))
         self._fetch_btn.clicked.connect(self._fetch_models)
         model_layout.addWidget(self._fetch_btn)
 
         self._model_status = QLabel()
-        self._model_status.setStyleSheet("color: #808080; font-size: 10px;")
+        self._model_status.setStyleSheet(maybe_host_stylesheet("color: #808080; font-size: 10px;"))
         self._model_status.setWordWrap(True)
         model_layout.addWidget(self._model_status)
         return model_layout
@@ -565,10 +576,9 @@ class SettingsDialog(QDialog):
 
     # --- Auth status ---
 
-    _OK_STYLE = "color: #4ec9b0; font-size: 11px; font-weight: bold;"
-    _ERR_STYLE = "color: #f44747; font-size: 11px;"
-
-    _HINT_STYLE = "color: #808080; font-size: 10px;"
+    _OK_STYLE = maybe_host_stylesheet("color: #4ec9b0; font-size: 11px; font-weight: bold;")
+    _ERR_STYLE = maybe_host_stylesheet("color: #f44747; font-size: 11px;")
+    _HINT_STYLE = maybe_host_stylesheet("color: #808080; font-size: 10px;")
 
     def _update_auth_status(self) -> None:
         provider_name = self._provider_combo.currentText()
@@ -640,10 +650,10 @@ class SettingsDialog(QDialog):
 
         if models:
             self._model_status.setText(f"{len(models)} models")
-            self._model_status.setStyleSheet("color: #4ec9b0; font-size: 10px;")
+            self._model_status.setStyleSheet(maybe_host_stylesheet("color: #4ec9b0; font-size: 10px;"))
         else:
             self._model_status.setText("Type model name manually")
-            self._model_status.setStyleSheet("color: #808080; font-size: 10px;")
+            self._model_status.setStyleSheet(maybe_host_stylesheet("color: #808080; font-size: 10px;"))
 
         # Auto-fill generation defaults based on selected model
         self._update_generation_defaults()
@@ -651,7 +661,7 @@ class SettingsDialog(QDialog):
     def _on_fetch_error(self, error: str) -> None:
         self._fetch_btn.setEnabled(True)
         self._model_status.setText(error)
-        self._model_status.setStyleSheet("color: #f44747; font-size: 10px;")
+        self._model_status.setStyleSheet(maybe_host_stylesheet("color: #f44747; font-size: 10px;"))
         self._model_restore_hint = ""
 
     def _update_generation_defaults(self) -> None:

--- a/rikugan/ui/styles.py
+++ b/rikugan/ui/styles.py
@@ -32,7 +32,7 @@ def _hex_luminance(color: str) -> float:
 
 def _blend_channel(a: int, b: int, amount: float) -> int:
     amount = max(0.0, min(1.0, amount))
-    return int(round(a + (b - a) * amount))
+    return round(a + (b - a) * amount)
 
 
 def blend_theme_color(color_a: str, color_b: str, amount: float) -> str:
@@ -44,10 +44,8 @@ def blend_theme_color(color_a: str, color_b: str, amount: float) -> str:
 
     ar, ag, ab = int(a[0:2], 16), int(a[2:4], 16), int(a[4:6], 16)
     br, bg, bb = int(b[0:2], 16), int(b[2:4], 16), int(b[4:6], 16)
-    return "#{:02x}{:02x}{:02x}".format(
-        _blend_channel(ar, br, amount),
-        _blend_channel(ag, bg, amount),
-        _blend_channel(ab, bb, amount),
+    return (
+        f"#{_blend_channel(ar, br, amount):02x}{_blend_channel(ag, bg, amount):02x}{_blend_channel(ab, bb, amount):02x}"
     )
 
 

--- a/rikugan/ui/styles.py
+++ b/rikugan/ui/styles.py
@@ -124,10 +124,9 @@ def get_host_palette_colors(source=None) -> dict[str, str]:
 def use_native_host_theme() -> bool:
     """Return True when the host should keep its own native theme.
 
-    IDA themes through a host stylesheet, so Rikugan should inherit the
-    host's widget styling instead of forcing Rikugan's standalone theme.
-    It should not force Rikugan's standalone colors on top of IDA.
-    ``DARK_THEME`` is applied instead — it matches IDA's dark chrome.
+    IDA owns the overall dock styling, but Rikugan still derives local
+    widget surfaces from the live host colors so the chat remains readable
+    in both light and dark themes.
     """
     return is_ida()
 
@@ -203,17 +202,6 @@ QScrollArea#chat_scroll {
 
 QWidget#chat_container {
     background: transparent;
-}
-
-QFrame#message_user,
-QFrame#message_assistant,
-QFrame#message_tool,
-QFrame#message_question,
-QFrame#message_queued,
-QFrame#message_thinking,
-QFrame#thinking_block {
-    background: transparent;
-    border: none;
 }
 
 QToolButton#collapse_button {

--- a/rikugan/ui/styles.py
+++ b/rikugan/ui/styles.py
@@ -1,6 +1,233 @@
-"""Dark-theme stylesheet for Rikugan UI."""
+"""Theme helpers and dark-theme stylesheet for Rikugan UI."""
 
 from __future__ import annotations
+
+from ..core.host import is_ida
+
+_FALLBACK_COLORS = {
+    "window": "#1e1e1e",
+    "window_text": "#d4d4d4",
+    "base": "#252526",
+    "alt_base": "#2d2d2d",
+    "text": "#d4d4d4",
+    "button": "#2d2d2d",
+    "button_text": "#d4d4d4",
+    "highlight": "#569cd6",
+    "highlight_text": "#ffffff",
+    "mid": "#808080",
+    "dark": "#1a1a1a",
+    "light": "#f3f3f3",
+}
+
+
+def _hex_luminance(color: str) -> float:
+    color = color.lstrip("#")
+    if len(color) != 6:
+        return 0.0
+    r = int(color[0:2], 16) / 255.0
+    g = int(color[2:4], 16) / 255.0
+    b = int(color[4:6], 16) / 255.0
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _blend_channel(a: int, b: int, amount: float) -> int:
+    amount = max(0.0, min(1.0, amount))
+    return int(round(a + (b - a) * amount))
+
+
+def blend_theme_color(color_a: str, color_b: str, amount: float) -> str:
+    """Blend two ``#rrggbb`` colors."""
+    a = color_a.lstrip("#")
+    b = color_b.lstrip("#")
+    if len(a) != 6 or len(b) != 6:
+        return color_a
+
+    ar, ag, ab = int(a[0:2], 16), int(a[2:4], 16), int(a[4:6], 16)
+    br, bg, bb = int(b[0:2], 16), int(b[2:4], 16), int(b[4:6], 16)
+    return "#{:02x}{:02x}{:02x}".format(
+        _blend_channel(ar, br, amount),
+        _blend_channel(ag, bg, amount),
+        _blend_channel(ab, bb, amount),
+    )
+
+
+def _normalize_ida_palette(colors: dict[str, str]) -> dict[str, str]:
+    """Derive control surfaces from IDA's dock background instead of native widget roles."""
+    window = colors["window"]
+    window_text = colors["window_text"]
+    is_dark = _hex_luminance(window) < 0.5
+    toward = "#ffffff" if is_dark else "#000000"
+    surface = blend_theme_color(window, toward, 0.08 if is_dark else 0.035)
+    alt_surface = blend_theme_color(window, toward, 0.14 if is_dark else 0.07)
+    mid = blend_theme_color(window, toward, 0.22 if is_dark else 0.16)
+    colors = dict(colors)
+    colors["base"] = surface
+    colors["button"] = surface
+    colors["alt_base"] = alt_surface
+    colors["text"] = window_text
+    colors["button_text"] = window_text
+    colors["mid"] = mid
+    colors["dark"] = blend_theme_color(window, "#000000", 0.20 if is_dark else 0.08)
+    colors["light"] = blend_theme_color(window, "#ffffff", 0.14 if is_dark else 0.20)
+    return colors
+
+
+def _palette_role(qpalette, role_name: str):
+    """Return a Qt palette role compatible with Qt5/Qt6 enum layouts."""
+    role = getattr(qpalette, role_name, None)
+    if role is not None:
+        return role
+    color_role = getattr(qpalette, "ColorRole", None)
+    if color_role is not None:
+        return getattr(color_role, role_name)
+    raise AttributeError(role_name)
+
+
+def get_host_palette_colors(source=None) -> dict[str, str]:
+    """Return the current Qt palette colors, with stable fallbacks."""
+    try:
+        from .qt_compat import QApplication, QPalette
+    except ImportError:
+        return dict(_FALLBACK_COLORS)
+
+    try:
+        palette = None
+        if source is not None and hasattr(source, "palette"):
+            palette = source.palette()
+        if palette is None:
+            instance = getattr(QApplication, "instance", None)
+            app = instance() if callable(instance) else None
+            if app is None or not hasattr(app, "palette"):
+                return dict(_FALLBACK_COLORS)
+            palette = app.palette()
+        colors = {
+            "window": palette.color(_palette_role(QPalette, "Window")).name(),
+            "window_text": palette.color(_palette_role(QPalette, "WindowText")).name(),
+            "base": palette.color(_palette_role(QPalette, "Base")).name(),
+            "alt_base": palette.color(_palette_role(QPalette, "AlternateBase")).name(),
+            "text": palette.color(_palette_role(QPalette, "Text")).name(),
+            "button": palette.color(_palette_role(QPalette, "Button")).name(),
+            "button_text": palette.color(_palette_role(QPalette, "ButtonText")).name(),
+            "highlight": palette.color(_palette_role(QPalette, "Highlight")).name(),
+            "highlight_text": palette.color(_palette_role(QPalette, "HighlightedText")).name(),
+            "mid": palette.color(_palette_role(QPalette, "Mid")).name(),
+            "dark": palette.color(_palette_role(QPalette, "Dark")).name(),
+            "light": palette.color(_palette_role(QPalette, "Light")).name(),
+        }
+        if use_native_host_theme():
+            colors = _normalize_ida_palette(colors)
+        return colors
+    except Exception:
+        return dict(_FALLBACK_COLORS)
+
+
+def use_native_host_theme() -> bool:
+    """Return True when the host should keep its own native theme.
+
+    IDA themes through a host stylesheet, so Rikugan should inherit the
+    host's widget styling instead of forcing Rikugan's standalone theme.
+    It should not force Rikugan's standalone colors on top of IDA.
+    ``DARK_THEME`` is applied instead — it matches IDA's dark chrome.
+    """
+    return is_ida()
+
+
+def maybe_host_stylesheet(css: str) -> str:
+    """Return the stylesheet unless the host should keep its native theme."""
+    return "" if use_native_host_theme() else css
+
+
+def host_stylesheet(custom_css: str, native_css: str = "") -> str:
+    """Return the stylesheet for the active host theme mode."""
+    return native_css if use_native_host_theme() else custom_css
+
+
+def build_theme_stylesheet(source=None) -> str:
+    """Return the active panel stylesheet for the current host."""
+    if use_native_host_theme():
+        return IDA_NATIVE_THEME
+    return DARK_THEME
+
+
+def build_small_button_stylesheet(source=None, danger: bool = False) -> str:
+    """Return a palette-aware small button stylesheet for host UIs."""
+    if use_native_host_theme():
+        return ""
+    colors = get_host_palette_colors(source)
+    bg = colors["button"]
+    fg = colors["button_text"]
+    border = blend_theme_color(colors["mid"], colors["window"], 0.35)
+    hover = blend_theme_color(bg, colors["light"], 0.12)
+    pressed = blend_theme_color(bg, colors["dark"], 0.12)
+    if danger:
+        fg = "#f87171"
+        border = blend_theme_color("#f44747", colors["window"], 0.2)
+    return (
+        f"QPushButton {{ background-color: {bg}; color: {fg}; border: 1px solid {border}; "
+        "border-radius: 6px; padding: 4px; font-size: 11px; }"
+        f"QPushButton:hover {{ background-color: {hover}; }}"
+        f"QPushButton:pressed {{ background-color: {pressed}; }}"
+        f"QPushButton:disabled {{ color: {blend_theme_color(fg, colors['window'], 0.45)}; "
+        f"border-color: {blend_theme_color(border, colors['window'], 0.35)}; }}"
+    )
+
+
+def build_input_area_stylesheet(source=None) -> str:
+    """Return a palette-aware input editor stylesheet."""
+    if use_native_host_theme():
+        return ""
+    colors = get_host_palette_colors(source)
+    bg = blend_theme_color(colors["window"], colors["button"], 0.22)
+    text = colors["window_text"]
+    border = blend_theme_color(colors["mid"], colors["window"], 0.35)
+    return (
+        "QPlainTextEdit#input_area { "
+        f"background-color: {bg}; color: {text}; "
+        f"border: 1px solid {border}; border-radius: 8px; "
+        "padding: 8px; font-size: 13px; "
+        f"selection-background-color: {colors['highlight']}; "
+        f"selection-color: {colors['highlight_text']}; }}"
+        f"QPlainTextEdit#input_area:focus {{ border-color: {colors['highlight']}; }}"
+    )
+
+
+IDA_NATIVE_THEME = """
+QWidget#rikugan_panel {
+    background: transparent;
+}
+
+QScrollArea#chat_scroll {
+    border: none;
+    background: transparent;
+}
+
+QWidget#chat_container {
+    background: transparent;
+}
+
+QFrame#message_user,
+QFrame#message_assistant,
+QFrame#message_tool,
+QFrame#message_question,
+QFrame#message_queued,
+QFrame#message_thinking,
+QFrame#thinking_block {
+    background: transparent;
+    border: none;
+}
+
+QToolButton#collapse_button {
+    border: none;
+    background: transparent;
+    padding: 0px;
+}
+
+QLabel#tool_content {
+    font-family: Consolas, "Courier New", monospace;
+    font-size: 10px;
+}
+"""
+
 
 DARK_THEME = """
 QWidget#rikugan_panel {

--- a/rikugan/ui/tabs/profiles_tab.py
+++ b/rikugan/ui/tabs/profiles_tab.py
@@ -14,7 +14,6 @@ from ...core.profile import (
     get_profile,
     list_profiles,
 )
-from ..styles import maybe_host_stylesheet
 from ..qt_compat import (
     QCheckBox,
     QComboBox,
@@ -32,6 +31,7 @@ from ..qt_compat import (
     QVBoxLayout,
     QWidget,
 )
+from ..styles import maybe_host_stylesheet
 
 if TYPE_CHECKING:
     from ..settings_service import SettingsService

--- a/rikugan/ui/tabs/profiles_tab.py
+++ b/rikugan/ui/tabs/profiles_tab.py
@@ -14,6 +14,7 @@ from ...core.profile import (
     get_profile,
     list_profiles,
 )
+from ..styles import maybe_host_stylesheet
 from ..qt_compat import (
     QCheckBox,
     QComboBox,
@@ -35,13 +36,13 @@ from ..qt_compat import (
 if TYPE_CHECKING:
     from ..settings_service import SettingsService
 
-_BTN_STYLE = (
+_BTN_STYLE = maybe_host_stylesheet(
     "QPushButton { background: #2d2d2d; color: #d4d4d4; border: 1px solid #3c3c3c; "
     "border-radius: 4px; padding: 4px 12px; font-size: 11px; }"
     "QPushButton:hover { background: #3c3c3c; }"
 )
 
-_GROUP_STYLE = (
+_GROUP_STYLE = maybe_host_stylesheet(
     "QGroupBox { font-weight: bold; border: 1px solid #3c3c3c; "
     "border-radius: 4px; margin-top: 14px; padding-top: 4px; }"
     "QGroupBox::title { subcontrol-origin: margin; left: 10px; "
@@ -268,11 +269,11 @@ class ProfilesTab(QWidget):
             for cat_name, tool_names in categories:
                 col = cols[col_idx % n_cols]
                 header = QLabel(f"<b>{cat_name}</b>")
-                header.setStyleSheet("font-size: 10px; color: #888; margin-top: 6px;")
+                header.setStyleSheet(maybe_host_stylesheet("font-size: 10px; color: #888; margin-top: 6px;"))
                 col.addWidget(header)
                 for tname in tool_names:
                     cb = QCheckBox(tname)
-                    cb.setStyleSheet("font-size: 11px;")
+                    cb.setStyleSheet(maybe_host_stylesheet("font-size: 11px;"))
                     self._denied_tool_cbs[tname] = cb
                     col.addWidget(cb)
                 col_idx += 1
@@ -559,7 +560,7 @@ class ProfilesTab(QWidget):
         lay.addLayout(form)
 
         error_label = QLabel()
-        error_label.setStyleSheet("color: #f44747; font-size: 11px;")
+        error_label.setStyleSheet(maybe_host_stylesheet("color: #f44747; font-size: 11px;"))
         error_label.hide()
         lay.addWidget(error_label)
 

--- a/rikugan/ui/tabs/skills_tab.py
+++ b/rikugan/ui/tabs/skills_tab.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...core.config import RikuganConfig
+from ...core.external_sources import get_external_skills_title
 from ...core.logging import log_debug
 from ...skills.loader import SkillDefinition
 from ..qt_compat import (
@@ -73,14 +74,7 @@ class SkillsTab(QWidget):
 
     def _build_external_group(self, source_key: str, skills: list[SkillDefinition]) -> QGroupBox:
         """Build a group box for external skills from one source."""
-        if source_key == "claude":
-            title = "Claude Code Skills (~/.claude/skills/)"
-        elif source_key == "codex":
-            title = "Codex Skills (~/.codex/skills/)"
-        else:
-            title = f"{source_key} Skills"
-
-        group = QGroupBox(title)
+        group = QGroupBox(get_external_skills_title(source_key))
         layout = QVBoxLayout(group)
 
         if not skills:

--- a/rikugan/ui/tool_widgets.py
+++ b/rikugan/ui/tool_widgets.py
@@ -27,6 +27,28 @@ from .qt_compat import (
 _MAX_ARGS_DISPLAY = 2000
 _MAX_RESULT_DISPLAY = 3000
 _TOOL_PREVIEW_LINES = 3
+_MUTED_TEXT = "#808080"
+_TOOL_BG = "#252526"
+_TOOL_BORDER = "#3c3c3c"
+
+
+def _tool_card_css(
+    source=None,
+    *,
+    accent: str | None = None,
+    background: str | None = None,
+    radius: int = 6,
+    object_name: str = "message_tool",
+) -> str:
+    del source
+    border = accent or _TOOL_BORDER
+    bg = background or _TOOL_BG
+    return (
+        f"QFrame#{object_name} {{ "
+        f"background-color: {bg}; border: 1px solid {border}; "
+        f"border-radius: {radius}px; "
+        "}"
+    )
 
 
 def _native_text_style(
@@ -377,15 +399,16 @@ def _truncate_preview(text: str, max_lines: int = _TOOL_PREVIEW_LINES) -> str:
     return f"{preview}\n\u2026 +{remaining} lines"
 
 
-def _make_preview_label() -> QLabel:
+def _make_preview_label(source=None) -> QLabel:
     """Create a collapsed-state preview QLabel (shared by ToolCallWidget/ToolBatchWidget)."""
+    del source
     lbl = QLabel()
     lbl.setObjectName("tool_content")
     lbl.setWordWrap(True)
     lbl.setStyleSheet(
         host_stylesheet(
             "color: #6a6a7a; font-family: monospace; font-size: 10px; margin-left: 28px;",
-            _native_text_style(size=10, monospace=True),
+            f"color: {_MUTED_TEXT}; {_native_text_style(size=10, monospace=True)}",
         )
     )
     lbl.setVisible(False)
@@ -481,6 +504,7 @@ class ToolCallWidget(QFrame):
     def __init__(self, tool_name: str, tool_call_id: str, parent: QWidget = None):
         super().__init__(parent)
         self.setObjectName("message_tool")
+        self.setStyleSheet(_tool_card_css(object_name="message_tool"))
         self._tool_name = tool_name
         self._tool_call_id = tool_call_id
         self._args_text = ""
@@ -518,7 +542,7 @@ class ToolCallWidget(QFrame):
         self._bullet.setStyleSheet(
             host_stylesheet(
                 f"color: {color}; font-size: 10px;",
-                _native_text_style(size=10),
+                f"color: {color}; {_native_text_style(size=10)}",
             )
         )
         self._bullet.setFixedWidth(14)
@@ -528,7 +552,7 @@ class ToolCallWidget(QFrame):
         self._name_label.setStyleSheet(
             host_stylesheet(
                 f"color: {color}; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: {color}; {_native_text_style(size=11, bold=True)}",
             )
         )
         header_layout.addWidget(self._name_label)
@@ -537,7 +561,7 @@ class ToolCallWidget(QFrame):
         self._summary_label.setStyleSheet(
             host_stylesheet(
                 "color: #808080; font-size: 11px; margin-left: 6px;",
-                _native_text_style(size=11),
+                f"color: {_MUTED_TEXT}; {_native_text_style(size=11)}",
             )
         )
         header_layout.addWidget(self._summary_label, 1)
@@ -546,7 +570,7 @@ class ToolCallWidget(QFrame):
         self._status_label.setStyleSheet(
             host_stylesheet(
                 "color: #dcdcaa; font-size: 10px;",
-                _native_text_style(size=10, bold=True),
+                f"color: #dcdcaa; {_native_text_style(size=10, bold=True)}",
             )
         )
         header_layout.addWidget(self._status_label)
@@ -555,7 +579,7 @@ class ToolCallWidget(QFrame):
 
     def _build_preview(self) -> QLabel:
         """Build the preview label (truncated args, shown when collapsed)."""
-        self._preview_label = _make_preview_label()
+        self._preview_label = _make_preview_label(self)
         return self._preview_label
 
     def _build_detail_section(self) -> QWidget:
@@ -580,7 +604,7 @@ class ToolCallWidget(QFrame):
         self._result_header.setStyleSheet(
             host_stylesheet(
                 "color: #808080; font-size: 10px; font-weight: bold;",
-                _native_text_style(size=10, bold=True),
+                f"color: {_MUTED_TEXT}; {_native_text_style(size=10, bold=True)}",
             )
         )
         self._result_header.setVisible(False)
@@ -646,20 +670,20 @@ class ToolCallWidget(QFrame):
             self._result_label.setStyleSheet(
                 host_stylesheet(
                     "color: #f44747; font-family: monospace; font-size: 11px;",
-                    _native_text_style(size=11, monospace=True),
+                    f"color: #f44747; {_native_text_style(size=11, monospace=True)}",
                 )
             )
             self._status_label.setText("\u2717")
             self._status_label.setStyleSheet(
                 host_stylesheet(
                     "color: #f44747; font-size: 10px;",
-                    _native_text_style(size=10, bold=True),
+                    f"color: #f44747; {_native_text_style(size=10, bold=True)}",
                 )
             )
             self._bullet.setStyleSheet(
                 host_stylesheet(
                     "color: #f44747; font-size: 10px;",
-                    _native_text_style(size=10),
+                    "color: #f44747; font-size: 10px;",
                 )
             )
             # Auto-expand on error
@@ -672,7 +696,7 @@ class ToolCallWidget(QFrame):
             self._status_label.setStyleSheet(
                 host_stylesheet(
                     "color: #4ec9b0; font-size: 10px;",
-                    _native_text_style(size=10, bold=True),
+                    f"color: #4ec9b0; {_native_text_style(size=10, bold=True)}",
                 )
             )
 
@@ -683,7 +707,7 @@ class ToolCallWidget(QFrame):
             self._status_label.setStyleSheet(
                 host_stylesheet(
                     "color: #4ec9b0; font-size: 10px;",
-                    _native_text_style(size=10, bold=True),
+                    f"color: #4ec9b0; {_native_text_style(size=10, bold=True)}",
                 )
             )
 
@@ -707,6 +731,7 @@ class ToolBatchWidget(QFrame):
     def __init__(self, tool_name: str, parent: QWidget = None):
         super().__init__(parent)
         self.setObjectName("message_tool")
+        self.setStyleSheet(_tool_card_css(object_name="message_tool"))
         self._tool_name = tool_name
         self._count = 0
         self._expanded = False
@@ -744,7 +769,7 @@ class ToolBatchWidget(QFrame):
         self._bullet.setStyleSheet(
             host_stylesheet(
                 f"color: {color}; font-size: 10px;",
-                _native_text_style(size=10),
+                f"color: {color}; {_native_text_style(size=10)}",
             )
         )
         self._bullet.setFixedWidth(14)
@@ -754,7 +779,7 @@ class ToolBatchWidget(QFrame):
         self._name_label.setStyleSheet(
             host_stylesheet(
                 f"color: {color}; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: {color}; {_native_text_style(size=11, bold=True)}",
             )
         )
         header_layout.addWidget(self._name_label)
@@ -763,7 +788,7 @@ class ToolBatchWidget(QFrame):
         self._count_label.setStyleSheet(
             host_stylesheet(
                 "color: #808080; font-size: 11px; margin-left: 6px;",
-                _native_text_style(size=11),
+                f"color: {_MUTED_TEXT}; {_native_text_style(size=11)}",
             )
         )
         header_layout.addWidget(self._count_label, 1)
@@ -772,7 +797,7 @@ class ToolBatchWidget(QFrame):
         self._status_label.setStyleSheet(
             host_stylesheet(
                 "color: #dcdcaa; font-size: 10px;",
-                _native_text_style(size=10, bold=True),
+                f"color: #dcdcaa; {_native_text_style(size=10, bold=True)}",
             )
         )
         header_layout.addWidget(self._status_label)
@@ -781,7 +806,7 @@ class ToolBatchWidget(QFrame):
 
     def _build_preview(self) -> QLabel:
         """Build the preview label for the first call's args."""
-        self._preview_label = _make_preview_label()
+        self._preview_label = _make_preview_label(self)
         return self._preview_label
 
     def _build_detail_section(self) -> QWidget:
@@ -813,7 +838,7 @@ class ToolBatchWidget(QFrame):
         entry.setStyleSheet(
             host_stylesheet(
                 "color: #808080; font-family: monospace; font-size: 10px;",
-                _native_text_style(size=10, monospace=True),
+                f"color: {_MUTED_TEXT}; {_native_text_style(size=10, monospace=True)}",
             )
         )
         entry.setWordWrap(True)
@@ -859,7 +884,7 @@ class ToolBatchWidget(QFrame):
                 self._status_label.setStyleSheet(
                     host_stylesheet(
                         "color: #f44747; font-size: 10px;",
-                        _native_text_style(size=10, bold=True),
+                        f"color: #f44747; {_native_text_style(size=10, bold=True)}",
                     )
                 )
             else:
@@ -867,7 +892,7 @@ class ToolBatchWidget(QFrame):
                 self._status_label.setStyleSheet(
                     host_stylesheet(
                         "color: #4ec9b0; font-size: 10px;",
-                        _native_text_style(size=10, bold=True),
+                        f"color: #4ec9b0; {_native_text_style(size=10, bold=True)}",
                     )
                 )
         else:
@@ -899,6 +924,7 @@ class ToolGroupWidget(QFrame):
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
         self.setObjectName("message_tool")
+        self.setStyleSheet(_tool_card_css(object_name="message_tool"))
         self._expanded = False
         self._count = 0
         self._done = 0
@@ -925,7 +951,7 @@ class ToolGroupWidget(QFrame):
         self._label.setStyleSheet(
             host_stylesheet(
                 "color: #808080; font-size: 11px; font-weight: bold;",
-                _native_text_style(size=11, bold=True),
+                f"color: {_MUTED_TEXT}; {_native_text_style(size=11, bold=True)}",
             )
         )
         header_layout.addWidget(self._label, 1)
@@ -934,7 +960,7 @@ class ToolGroupWidget(QFrame):
         self._status_label.setStyleSheet(
             host_stylesheet(
                 "color: #dcdcaa; font-size: 10px;",
-                _native_text_style(size=10, bold=True),
+                f"color: #dcdcaa; {_native_text_style(size=10, bold=True)}",
             )
         )
         header_layout.addWidget(self._status_label)
@@ -974,7 +1000,7 @@ class ToolGroupWidget(QFrame):
                 self._status_label.setStyleSheet(
                     host_stylesheet(
                         "color: #f44747; font-size: 10px;",
-                        _native_text_style(size=10, bold=True),
+                        f"color: #f44747; {_native_text_style(size=10, bold=True)}",
                     )
                 )
             else:
@@ -982,7 +1008,7 @@ class ToolGroupWidget(QFrame):
                 self._status_label.setStyleSheet(
                     host_stylesheet(
                         "color: #4ec9b0; font-size: 10px;",
-                        _native_text_style(size=10, bold=True),
+                        f"color: #4ec9b0; {_native_text_style(size=10, bold=True)}",
                     )
                 )
         else:
@@ -990,7 +1016,7 @@ class ToolGroupWidget(QFrame):
             self._status_label.setStyleSheet(
                 host_stylesheet(
                     "color: #dcdcaa; font-size: 10px;",
-                    _native_text_style(size=10, bold=True),
+                    f"color: #dcdcaa; {_native_text_style(size=10, bold=True)}",
                 )
             )
 
@@ -1137,7 +1163,12 @@ class ToolApprovalWidget(QFrame):
         self.setStyleSheet(
             host_stylesheet(
                 "QFrame#message_question { border: 1px solid #dcdcaa; border-radius: 6px; background: #2d2d1e; }",
-                "QFrame#message_question { background: transparent; border: none; }",
+                _tool_card_css(
+                    parent or self,
+                    accent="#dcdcaa",
+                    background="#2d2d1e",
+                    object_name="message_question",
+                ),
             )
         )
         self._tool_call_id = tool_call_id
@@ -1149,7 +1180,7 @@ class ToolApprovalWidget(QFrame):
         self._header.setStyleSheet(
             host_stylesheet(
                 "color: #dcdcaa; font-weight: bold; font-size: 11px;",
-                _native_text_style(size=11, bold=True),
+                f"color: #dcdcaa; {_native_text_style(size=11, bold=True)}",
             )
         )
         layout.addWidget(self._header)
@@ -1161,7 +1192,7 @@ class ToolApprovalWidget(QFrame):
         self._info.setStyleSheet(
             host_stylesheet(
                 "color: #808080; font-size: 10px;",
-                _native_text_style(size=10),
+                f"color: {_MUTED_TEXT}; {_native_text_style(size=10)}",
             )
         )
         layout.addWidget(self._info)
@@ -1220,36 +1251,39 @@ class ToolApprovalWidget(QFrame):
 
         self._allow_btn = QToolButton()
         self._allow_btn.setText("  Allow  ")
+        allow_css = (
+            "QToolButton { background: #2ea043; color: #ffffff; border: none; "
+            "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
+            "QToolButton:hover { background: #3fb950; }"
+        )
         self._allow_btn.setStyleSheet(
-            host_stylesheet(
-                "QToolButton { background: #2ea043; color: #ffffff; border: none; "
-                "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
-                "QToolButton:hover { background: #3fb950; }"
-            )
+            host_stylesheet(allow_css, allow_css)
         )
         self._allow_btn.clicked.connect(self._on_allow)
         btn_layout.addWidget(self._allow_btn)
 
         self._always_btn = QToolButton()
         self._always_btn.setText("  Always Allow  ")
+        always_css = (
+            "QToolButton { background: #1a5c2d; color: #ffffff; border: none; "
+            "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
+            "QToolButton:hover { background: #2ea043; }"
+        )
         self._always_btn.setStyleSheet(
-            host_stylesheet(
-                "QToolButton { background: #1a5c2d; color: #ffffff; border: none; "
-                "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
-                "QToolButton:hover { background: #2ea043; }"
-            )
+            host_stylesheet(always_css, always_css)
         )
         self._always_btn.clicked.connect(self._on_always_allow)
         btn_layout.addWidget(self._always_btn)
 
         self._deny_btn = QToolButton()
         self._deny_btn.setText("  Deny  ")
+        deny_css = (
+            "QToolButton { background: #c42b1c; color: #ffffff; border: none; "
+            "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
+            "QToolButton:hover { background: #e04030; }"
+        )
         self._deny_btn.setStyleSheet(
-            host_stylesheet(
-                "QToolButton { background: #c42b1c; color: #ffffff; border: none; "
-                "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
-                "QToolButton:hover { background: #e04030; }"
-            )
+            host_stylesheet(deny_css, deny_css)
         )
         self._deny_btn.clicked.connect(self._on_deny)
         btn_layout.addWidget(self._deny_btn)
@@ -1265,11 +1299,12 @@ class ToolApprovalWidget(QFrame):
     def _on_allow(self):
         self._disable_buttons()
         self._allow_btn.setText("  Allowed  ")
+        allowed_css = (
+            "QToolButton { background: #1a5c2d; color: #808080; border: none; "
+            "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
+        )
         self._allow_btn.setStyleSheet(
-            host_stylesheet(
-                "QToolButton { background: #1a5c2d; color: #808080; border: none; "
-                "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
-            )
+            host_stylesheet(allowed_css, allowed_css)
         )
         if self._approved_callback is not None:
             self._approved_callback(self._tool_call_id, "allow")
@@ -1277,11 +1312,12 @@ class ToolApprovalWidget(QFrame):
     def _on_always_allow(self):
         self._disable_buttons()
         self._always_btn.setText("  Always Allowed  ")
+        always_allowed_css = (
+            "QToolButton { background: #1a5c2d; color: #808080; border: none; "
+            "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
+        )
         self._always_btn.setStyleSheet(
-            host_stylesheet(
-                "QToolButton { background: #1a5c2d; color: #808080; border: none; "
-                "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
-            )
+            host_stylesheet(always_allowed_css, always_allowed_css)
         )
         if self._approved_callback is not None:
             self._approved_callback(self._tool_call_id, "allow_all")
@@ -1289,11 +1325,12 @@ class ToolApprovalWidget(QFrame):
     def _on_deny(self):
         self._disable_buttons()
         self._deny_btn.setText("  Denied  ")
+        denied_css = (
+            "QToolButton { background: #6e1a12; color: #808080; border: none; "
+            "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
+        )
         self._deny_btn.setStyleSheet(
-            host_stylesheet(
-                "QToolButton { background: #6e1a12; color: #808080; border: none; "
-                "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
-            )
+            host_stylesheet(denied_css, denied_css)
         )
         if self._approved_callback is not None:
             self._approved_callback(self._tool_call_id, "deny")

--- a/rikugan/ui/tool_widgets.py
+++ b/rikugan/ui/tool_widgets.py
@@ -6,7 +6,6 @@ import json
 import re as _re
 from typing import ClassVar
 
-from .styles import host_stylesheet, use_native_host_theme
 from .qt_compat import (
     QColor,
     QFont,
@@ -23,6 +22,7 @@ from .qt_compat import (
     QWidget,
     qt_flags,
 )
+from .styles import host_stylesheet, use_native_host_theme
 
 _MAX_ARGS_DISPLAY = 2000
 _MAX_RESULT_DISPLAY = 3000

--- a/rikugan/ui/tool_widgets.py
+++ b/rikugan/ui/tool_widgets.py
@@ -47,8 +47,9 @@ def _native_text_style(
         parts.append('font-family: Consolas, "Courier New", monospace;')
     return " ".join(parts)
 
+
 # ---------------------------------------------------------------------------
-# MCP prefix stripping — works with any MCP server, not just a specific one
+# MCP prefix stripping - works with any MCP server, not just a specific one
 # ---------------------------------------------------------------------------
 
 
@@ -63,7 +64,7 @@ def _strip_mcp_prefix(name: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Tool-specific colors (by base name — MCP prefix is stripped before lookup)
+# Tool-specific colors (by base name - MCP prefix is stripped before lookup)
 # ---------------------------------------------------------------------------
 _TOOL_COLORS: dict[str, str] = {}
 
@@ -235,14 +236,14 @@ def _format_tool_summary(tool_name: str, args_text: str) -> str:
         old = _get("old_name", "current_name", "ea")
         new = _get("new_name")
         if old and new:
-            summary = f"{old} → {new}"
+            summary = f"{old} \u2192 {new}"
 
     elif short_name in ("rename_single_variable", "rename_variable"):
         func = _get("function_name", "function", "ea")
         old = _get("variable_name", "var_name", "old_name")
         new = _get("new_name")
         if old and new:
-            summary = f"{func}: {old} → {new}" if func else f"{old} → {new}"
+            summary = f"{func}: {old} \u2192 {new}" if func else f"{old} \u2192 {new}"
 
     elif short_name in ("rename_multi_variables",):
         func = _get("function_identifier", "function_name", "ea")
@@ -340,7 +341,7 @@ def _format_tool_summary(tool_name: str, args_text: str) -> str:
         reason = _get("reason")
         if reason and len(reason) > 40:
             reason = reason[:37] + "..."
-        summary = f"→ {phase}" + (f": {reason}" if reason else "")
+        summary = f"\u2192 {phase}" + (f": {reason}" if reason else "")
 
     else:
         # Generic: try common parameter names
@@ -367,13 +368,13 @@ def _format_tool_summary(tool_name: str, args_text: str) -> str:
 
 
 def _truncate_preview(text: str, max_lines: int = _TOOL_PREVIEW_LINES) -> str:
-    """Return first N lines with a '… +M lines' indicator if truncated."""
+    """Return first N lines with a '... +M lines' indicator if truncated."""
     lines = text.split("\n")
     if len(lines) <= max_lines:
         return text
     preview = "\n".join(lines[:max_lines])
     remaining = len(lines) - max_lines
-    return f"{preview}\n… +{remaining} lines"
+    return f"{preview}\n\u2026 +{remaining} lines"
 
 
 def _make_preview_label() -> QLabel:
@@ -460,11 +461,22 @@ class _SharedSpinnerTimer:
 class ToolCallWidget(QFrame):
     """Compact tool call display.
 
-    Shows:  ● tool_name  summary_text
+    Shows:  [dot] tool_name  summary_text
     With a collapsible detail section for args and result.
     """
 
-    _SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
+    _SPINNER_FRAMES = (
+        "\u280b",
+        "\u2819",
+        "\u2839",
+        "\u2838",
+        "\u283c",
+        "\u2834",
+        "\u2826",
+        "\u2827",
+        "\u2807",
+        "\u280f",
+    )
 
     def __init__(self, tool_name: str, tool_call_id: str, parent: QWidget = None):
         super().__init__(parent)
@@ -487,7 +499,7 @@ class ToolCallWidget(QFrame):
         layout.addWidget(self._build_detail_section())
 
     def _build_header(self, tool_name: str) -> QHBoxLayout:
-        """Build the compact header row: toggle ● name  summary  status."""
+        """Build the compact header row: toggle bullet name summary status."""
         display_name = _strip_mcp_prefix(tool_name)
         color = _tool_color(tool_name)
 
@@ -497,12 +509,12 @@ class ToolCallWidget(QFrame):
 
         self._toggle_btn = QToolButton()
         self._toggle_btn.setObjectName("collapse_button")
-        self._toggle_btn.setText("▶")
+        self._toggle_btn.setText("\u25b6")
         self._toggle_btn.setFixedSize(14, 14)
         self._toggle_btn.clicked.connect(self._toggle)
         header_layout.addWidget(self._toggle_btn)
 
-        self._bullet = QLabel("●")
+        self._bullet = QLabel("\u25cf")
         self._bullet.setStyleSheet(
             host_stylesheet(
                 f"color: {color}; font-size: 10px;",
@@ -602,7 +614,7 @@ class ToolCallWidget(QFrame):
         self._expanded = not self._expanded
         self._detail_widget.setVisible(self._expanded)
         self._preview_label.setVisible(not self._expanded and bool(self._args_text))
-        self._toggle_btn.setText("▼" if self._expanded else "▶")
+        self._toggle_btn.setText("\u25bc" if self._expanded else "\u25b6")
 
     def set_arguments(self, args_text: str) -> None:
         self._args_text = args_text
@@ -620,7 +632,7 @@ class ToolCallWidget(QFrame):
 
     def append_args_delta(self, delta: str) -> None:
         self._args_text += delta
-        # Don't update preview during streaming — wait for set_arguments
+        # Don't update preview during streaming - wait for set_arguments
 
     def set_result(self, result: str, is_error: bool = False) -> None:
         self._stop_spinner()
@@ -637,7 +649,7 @@ class ToolCallWidget(QFrame):
                     _native_text_style(size=11, monospace=True),
                 )
             )
-            self._status_label.setText("✗")
+            self._status_label.setText("\u2717")
             self._status_label.setStyleSheet(
                 host_stylesheet(
                     "color: #f44747; font-size: 10px;",
@@ -654,9 +666,9 @@ class ToolCallWidget(QFrame):
             self._expanded = True
             self._detail_widget.setVisible(True)
             self._preview_label.setVisible(False)
-            self._toggle_btn.setText("▼")
+            self._toggle_btn.setText("\u25bc")
         else:
-            self._status_label.setText("✓")
+            self._status_label.setText("\u2713")
             self._status_label.setStyleSheet(
                 host_stylesheet(
                     "color: #4ec9b0; font-size: 10px;",
@@ -666,8 +678,8 @@ class ToolCallWidget(QFrame):
 
     def mark_done(self) -> None:
         self._stop_spinner()
-        if self._status_label.text() not in ("✓", "✗"):
-            self._status_label.setText("✓")
+        if self._status_label.text() not in ("\u2713", "\u2717"):
+            self._status_label.setText("\u2713")
             self._status_label.setStyleSheet(
                 host_stylesheet(
                     "color: #4ec9b0; font-size: 10px;",
@@ -681,14 +693,14 @@ class ToolCallWidget(QFrame):
 
 
 # ---------------------------------------------------------------------------
-# Tool batch widget — groups N consecutive calls to the same tool
+# Tool batch widget - groups N consecutive calls to the same tool
 # ---------------------------------------------------------------------------
 
 
 class ToolBatchWidget(QFrame):
     """Groups consecutive calls to the same tool.
 
-    Shows:  ● tool_name  (N calls)
+    Shows:  [dot] tool_name  (N calls)
     With preview of the first call's args.
     """
 
@@ -713,7 +725,7 @@ class ToolBatchWidget(QFrame):
         layout.addWidget(self._build_detail_section())
 
     def _build_header(self, tool_name: str) -> QHBoxLayout:
-        """Build the compact header row: toggle ● name  count  status."""
+        """Build the compact header row: toggle bullet name count status."""
         display_name = _strip_mcp_prefix(tool_name)
         color = _tool_color(tool_name)
 
@@ -723,12 +735,12 @@ class ToolBatchWidget(QFrame):
 
         self._toggle_btn = QToolButton()
         self._toggle_btn.setObjectName("collapse_button")
-        self._toggle_btn.setText("▶")
+        self._toggle_btn.setText("\u25b6")
         self._toggle_btn.setFixedSize(14, 14)
         self._toggle_btn.clicked.connect(self._toggle)
         header_layout.addWidget(self._toggle_btn)
 
-        self._bullet = QLabel("●")
+        self._bullet = QLabel("\u25cf")
         self._bullet.setStyleSheet(
             host_stylesheet(
                 f"color: {color}; font-size: 10px;",
@@ -756,7 +768,7 @@ class ToolBatchWidget(QFrame):
         )
         header_layout.addWidget(self._count_label, 1)
 
-        self._status_label = QLabel("…")
+        self._status_label = QLabel("\u2026")
         self._status_label.setStyleSheet(
             host_stylesheet(
                 "color: #dcdcaa; font-size: 10px;",
@@ -843,7 +855,7 @@ class ToolBatchWidget(QFrame):
         done = len(self._results) + len(self._errors)
         if done >= self._count:
             if self._errors:
-                self._status_label.setText(f"✓{len(self._results)} ✗{len(self._errors)}")
+                self._status_label.setText(f"\u2713{len(self._results)} \u2717{len(self._errors)}")
                 self._status_label.setStyleSheet(
                     host_stylesheet(
                         "color: #f44747; font-size: 10px;",
@@ -851,7 +863,7 @@ class ToolBatchWidget(QFrame):
                     )
                 )
             else:
-                self._status_label.setText("✓")
+                self._status_label.setText("\u2713")
                 self._status_label.setStyleSheet(
                     host_stylesheet(
                         "color: #4ec9b0; font-size: 10px;",
@@ -865,7 +877,7 @@ class ToolBatchWidget(QFrame):
         self._expanded = not self._expanded
         self._detail_widget.setVisible(self._expanded)
         self._preview_label.setVisible(not self._expanded and bool(self._first_args))
-        self._toggle_btn.setText("▼" if self._expanded else "▶")
+        self._toggle_btn.setText("\u25bc" if self._expanded else "\u25b6")
 
     @property
     def tool_name(self) -> str:
@@ -877,7 +889,7 @@ class ToolBatchWidget(QFrame):
 
 
 # ---------------------------------------------------------------------------
-# Tool group widget — collapsible container for runs of tool calls
+# Tool group widget - collapsible container for runs of tool calls
 # ---------------------------------------------------------------------------
 
 
@@ -897,14 +909,14 @@ class ToolGroupWidget(QFrame):
         layout.setContentsMargins(6, 3, 6, 3)
         layout.setSpacing(0)
 
-        # Header: ▶ <summary label>  ✓
+        # Header: > <summary label> ok
         header_layout = QHBoxLayout()
         header_layout.setContentsMargins(0, 0, 0, 0)
         header_layout.setSpacing(6)
 
         self._toggle_btn = QToolButton()
         self._toggle_btn.setObjectName("collapse_button")
-        self._toggle_btn.setText("▶")
+        self._toggle_btn.setText("\u25b6")
         self._toggle_btn.setFixedSize(14, 14)
         self._toggle_btn.clicked.connect(self._toggle)
         header_layout.addWidget(self._toggle_btn)
@@ -958,7 +970,7 @@ class ToolGroupWidget(QFrame):
         if self._done >= self._count:
             if self._errors:
                 ok = self._done - self._errors
-                self._status_label.setText(f"✓{ok} ✗{self._errors}")
+                self._status_label.setText(f"\u2713{ok} \u2717{self._errors}")
                 self._status_label.setStyleSheet(
                     host_stylesheet(
                         "color: #f44747; font-size: 10px;",
@@ -966,7 +978,7 @@ class ToolGroupWidget(QFrame):
                     )
                 )
             else:
-                self._status_label.setText("✓")
+                self._status_label.setText("\u2713")
                 self._status_label.setStyleSheet(
                     host_stylesheet(
                         "color: #4ec9b0; font-size: 10px;",
@@ -985,7 +997,7 @@ class ToolGroupWidget(QFrame):
     def _toggle(self) -> None:
         self._expanded = not self._expanded
         self._body.setVisible(self._expanded)
-        self._toggle_btn.setText("▼" if self._expanded else "▶")
+        self._toggle_btn.setText("\u25bc" if self._expanded else "\u25b6")
 
     @property
     def count(self) -> int:
@@ -1000,7 +1012,7 @@ class ToolGroupWidget(QFrame):
 class _PythonHighlighter(QSyntaxHighlighter):
     """Minimal VS Code-dark-style Python syntax highlighter."""
 
-    _RULES: ClassVar[list] = []  # built once in __init_subclass__ — see below
+    _RULES: ClassVar[list] = []  # built once in __init_subclass__ - see below
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -1145,7 +1157,7 @@ class ToolApprovalWidget(QFrame):
         code = self._extract_code(args_text)
         code_lines = code.strip().splitlines() if code.strip() else []
 
-        self._info = QLabel(f"Python code — {len(code_lines)} line{'s' if len(code_lines) != 1 else ''}")
+        self._info = QLabel(f"Python code - {len(code_lines)} line{'s' if len(code_lines) != 1 else ''}")
         self._info.setStyleSheet(
             host_stylesheet(
                 "color: #808080; font-size: 10px;",

--- a/rikugan/ui/tool_widgets.py
+++ b/rikugan/ui/tool_widgets.py
@@ -43,12 +43,7 @@ def _tool_card_css(
     del source
     border = accent or _TOOL_BORDER
     bg = background or _TOOL_BG
-    return (
-        f"QFrame#{object_name} {{ "
-        f"background-color: {bg}; border: 1px solid {border}; "
-        f"border-radius: {radius}px; "
-        "}"
-    )
+    return f"QFrame#{object_name} {{ background-color: {bg}; border: 1px solid {border}; border-radius: {radius}px; }}"
 
 
 def _native_text_style(
@@ -1256,9 +1251,7 @@ class ToolApprovalWidget(QFrame):
             "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
             "QToolButton:hover { background: #3fb950; }"
         )
-        self._allow_btn.setStyleSheet(
-            host_stylesheet(allow_css, allow_css)
-        )
+        self._allow_btn.setStyleSheet(host_stylesheet(allow_css, allow_css))
         self._allow_btn.clicked.connect(self._on_allow)
         btn_layout.addWidget(self._allow_btn)
 
@@ -1269,9 +1262,7 @@ class ToolApprovalWidget(QFrame):
             "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
             "QToolButton:hover { background: #2ea043; }"
         )
-        self._always_btn.setStyleSheet(
-            host_stylesheet(always_css, always_css)
-        )
+        self._always_btn.setStyleSheet(host_stylesheet(always_css, always_css))
         self._always_btn.clicked.connect(self._on_always_allow)
         btn_layout.addWidget(self._always_btn)
 
@@ -1282,9 +1273,7 @@ class ToolApprovalWidget(QFrame):
             "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
             "QToolButton:hover { background: #e04030; }"
         )
-        self._deny_btn.setStyleSheet(
-            host_stylesheet(deny_css, deny_css)
-        )
+        self._deny_btn.setStyleSheet(host_stylesheet(deny_css, deny_css))
         self._deny_btn.clicked.connect(self._on_deny)
         btn_layout.addWidget(self._deny_btn)
 
@@ -1303,9 +1292,7 @@ class ToolApprovalWidget(QFrame):
             "QToolButton { background: #1a5c2d; color: #808080; border: none; "
             "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
         )
-        self._allow_btn.setStyleSheet(
-            host_stylesheet(allowed_css, allowed_css)
-        )
+        self._allow_btn.setStyleSheet(host_stylesheet(allowed_css, allowed_css))
         if self._approved_callback is not None:
             self._approved_callback(self._tool_call_id, "allow")
 
@@ -1316,9 +1303,7 @@ class ToolApprovalWidget(QFrame):
             "QToolButton { background: #1a5c2d; color: #808080; border: none; "
             "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
         )
-        self._always_btn.setStyleSheet(
-            host_stylesheet(always_allowed_css, always_allowed_css)
-        )
+        self._always_btn.setStyleSheet(host_stylesheet(always_allowed_css, always_allowed_css))
         if self._approved_callback is not None:
             self._approved_callback(self._tool_call_id, "allow_all")
 
@@ -1329,8 +1314,6 @@ class ToolApprovalWidget(QFrame):
             "QToolButton { background: #6e1a12; color: #808080; border: none; "
             "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
         )
-        self._deny_btn.setStyleSheet(
-            host_stylesheet(denied_css, denied_css)
-        )
+        self._deny_btn.setStyleSheet(host_stylesheet(denied_css, denied_css))
         if self._approved_callback is not None:
             self._approved_callback(self._tool_call_id, "deny")

--- a/rikugan/ui/tool_widgets.py
+++ b/rikugan/ui/tool_widgets.py
@@ -6,6 +6,7 @@ import json
 import re as _re
 from typing import ClassVar
 
+from .styles import host_stylesheet, use_native_host_theme
 from .qt_compat import (
     QColor,
     QFont,
@@ -26,6 +27,25 @@ from .qt_compat import (
 _MAX_ARGS_DISPLAY = 2000
 _MAX_RESULT_DISPLAY = 3000
 _TOOL_PREVIEW_LINES = 3
+
+
+def _native_text_style(
+    *,
+    size: int | None = None,
+    bold: bool = False,
+    italic: bool = False,
+    monospace: bool = False,
+) -> str:
+    parts: list[str] = []
+    if size is not None:
+        parts.append(f"font-size: {size}px;")
+    if bold:
+        parts.append("font-weight: bold;")
+    if italic:
+        parts.append("font-style: italic;")
+    if monospace:
+        parts.append('font-family: Consolas, "Courier New", monospace;')
+    return " ".join(parts)
 
 # ---------------------------------------------------------------------------
 # MCP prefix stripping — works with any MCP server, not just a specific one
@@ -361,7 +381,12 @@ def _make_preview_label() -> QLabel:
     lbl = QLabel()
     lbl.setObjectName("tool_content")
     lbl.setWordWrap(True)
-    lbl.setStyleSheet("color: #6a6a7a; font-family: monospace; font-size: 10px; margin-left: 28px;")
+    lbl.setStyleSheet(
+        host_stylesheet(
+            "color: #6a6a7a; font-family: monospace; font-size: 10px; margin-left: 28px;",
+            _native_text_style(size=10, monospace=True),
+        )
+    )
     lbl.setVisible(False)
     return lbl
 
@@ -478,20 +503,40 @@ class ToolCallWidget(QFrame):
         header_layout.addWidget(self._toggle_btn)
 
         self._bullet = QLabel("●")
-        self._bullet.setStyleSheet(f"color: {color}; font-size: 10px;")
+        self._bullet.setStyleSheet(
+            host_stylesheet(
+                f"color: {color}; font-size: 10px;",
+                _native_text_style(size=10),
+            )
+        )
         self._bullet.setFixedWidth(14)
         header_layout.addWidget(self._bullet)
 
         self._name_label = QLabel(display_name)
-        self._name_label.setStyleSheet(f"color: {color}; font-weight: bold; font-size: 11px;")
+        self._name_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {color}; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         header_layout.addWidget(self._name_label)
 
         self._summary_label = QLabel("")
-        self._summary_label.setStyleSheet("color: #808080; font-size: 11px; margin-left: 6px;")
+        self._summary_label.setStyleSheet(
+            host_stylesheet(
+                "color: #808080; font-size: 11px; margin-left: 6px;",
+                _native_text_style(size=11),
+            )
+        )
         header_layout.addWidget(self._summary_label, 1)
 
         self._status_label = QLabel(self._SPINNER_FRAMES[0])
-        self._status_label.setStyleSheet("color: #dcdcaa; font-size: 10px;")
+        self._status_label.setStyleSheet(
+            host_stylesheet(
+                "color: #dcdcaa; font-size: 10px;",
+                _native_text_style(size=10, bold=True),
+            )
+        )
         header_layout.addWidget(self._status_label)
 
         return header_layout
@@ -520,7 +565,12 @@ class ToolCallWidget(QFrame):
         self._detail_layout.addWidget(self._args_label)
 
         self._result_header = QLabel("Result:")
-        self._result_header.setStyleSheet("color: #808080; font-size: 10px; font-weight: bold;")
+        self._result_header.setStyleSheet(
+            host_stylesheet(
+                "color: #808080; font-size: 10px; font-weight: bold;",
+                _native_text_style(size=10, bold=True),
+            )
+        )
         self._result_header.setVisible(False)
         self._detail_layout.addWidget(self._result_header)
 
@@ -581,10 +631,25 @@ class ToolCallWidget(QFrame):
         self._result_label.setVisible(True)
         self._result_header.setVisible(True)
         if is_error:
-            self._result_label.setStyleSheet("color: #f44747; font-family: monospace; font-size: 11px;")
+            self._result_label.setStyleSheet(
+                host_stylesheet(
+                    "color: #f44747; font-family: monospace; font-size: 11px;",
+                    _native_text_style(size=11, monospace=True),
+                )
+            )
             self._status_label.setText("✗")
-            self._status_label.setStyleSheet("color: #f44747; font-size: 10px;")
-            self._bullet.setStyleSheet("color: #f44747; font-size: 10px;")
+            self._status_label.setStyleSheet(
+                host_stylesheet(
+                    "color: #f44747; font-size: 10px;",
+                    _native_text_style(size=10, bold=True),
+                )
+            )
+            self._bullet.setStyleSheet(
+                host_stylesheet(
+                    "color: #f44747; font-size: 10px;",
+                    _native_text_style(size=10),
+                )
+            )
             # Auto-expand on error
             self._expanded = True
             self._detail_widget.setVisible(True)
@@ -592,13 +657,23 @@ class ToolCallWidget(QFrame):
             self._toggle_btn.setText("▼")
         else:
             self._status_label.setText("✓")
-            self._status_label.setStyleSheet("color: #4ec9b0; font-size: 10px;")
+            self._status_label.setStyleSheet(
+                host_stylesheet(
+                    "color: #4ec9b0; font-size: 10px;",
+                    _native_text_style(size=10, bold=True),
+                )
+            )
 
     def mark_done(self) -> None:
         self._stop_spinner()
         if self._status_label.text() not in ("✓", "✗"):
             self._status_label.setText("✓")
-            self._status_label.setStyleSheet("color: #4ec9b0; font-size: 10px;")
+            self._status_label.setStyleSheet(
+                host_stylesheet(
+                    "color: #4ec9b0; font-size: 10px;",
+                    _native_text_style(size=10, bold=True),
+                )
+            )
 
     def hide_preview(self) -> None:
         """Hide the args preview (used when preview budget exhausted)."""
@@ -654,20 +729,40 @@ class ToolBatchWidget(QFrame):
         header_layout.addWidget(self._toggle_btn)
 
         self._bullet = QLabel("●")
-        self._bullet.setStyleSheet(f"color: {color}; font-size: 10px;")
+        self._bullet.setStyleSheet(
+            host_stylesheet(
+                f"color: {color}; font-size: 10px;",
+                _native_text_style(size=10),
+            )
+        )
         self._bullet.setFixedWidth(14)
         header_layout.addWidget(self._bullet)
 
         self._name_label = QLabel(display_name)
-        self._name_label.setStyleSheet(f"color: {color}; font-weight: bold; font-size: 11px;")
+        self._name_label.setStyleSheet(
+            host_stylesheet(
+                f"color: {color}; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         header_layout.addWidget(self._name_label)
 
         self._count_label = QLabel("")
-        self._count_label.setStyleSheet("color: #808080; font-size: 11px; margin-left: 6px;")
+        self._count_label.setStyleSheet(
+            host_stylesheet(
+                "color: #808080; font-size: 11px; margin-left: 6px;",
+                _native_text_style(size=11),
+            )
+        )
         header_layout.addWidget(self._count_label, 1)
 
         self._status_label = QLabel("…")
-        self._status_label.setStyleSheet("color: #dcdcaa; font-size: 10px;")
+        self._status_label.setStyleSheet(
+            host_stylesheet(
+                "color: #dcdcaa; font-size: 10px;",
+                _native_text_style(size=10, bold=True),
+            )
+        )
         header_layout.addWidget(self._status_label)
 
         return header_layout
@@ -703,7 +798,12 @@ class ToolBatchWidget(QFrame):
         # Add entry in detail area
         summary = _format_tool_summary(self._tool_name, args_text) if args_text else ""
         entry = QLabel(f"#{self._count}: {summary}" if summary else f"#{self._count}")
-        entry.setStyleSheet("color: #808080; font-family: monospace; font-size: 10px;")
+        entry.setStyleSheet(
+            host_stylesheet(
+                "color: #808080; font-family: monospace; font-size: 10px;",
+                _native_text_style(size=10, monospace=True),
+            )
+        )
         entry.setWordWrap(True)
         self._entry_labels.append(entry)  # prevent Shiboken GC
         self._detail_layout.addWidget(entry)
@@ -744,10 +844,20 @@ class ToolBatchWidget(QFrame):
         if done >= self._count:
             if self._errors:
                 self._status_label.setText(f"✓{len(self._results)} ✗{len(self._errors)}")
-                self._status_label.setStyleSheet("color: #f44747; font-size: 10px;")
+                self._status_label.setStyleSheet(
+                    host_stylesheet(
+                        "color: #f44747; font-size: 10px;",
+                        _native_text_style(size=10, bold=True),
+                    )
+                )
             else:
                 self._status_label.setText("✓")
-                self._status_label.setStyleSheet("color: #4ec9b0; font-size: 10px;")
+                self._status_label.setStyleSheet(
+                    host_stylesheet(
+                        "color: #4ec9b0; font-size: 10px;",
+                        _native_text_style(size=10, bold=True),
+                    )
+                )
         else:
             self._status_label.setText(f"{done}/{self._count}")
 
@@ -800,11 +910,21 @@ class ToolGroupWidget(QFrame):
         header_layout.addWidget(self._toggle_btn)
 
         self._label = QLabel("0 tools called")
-        self._label.setStyleSheet("color: #808080; font-size: 11px; font-weight: bold;")
+        self._label.setStyleSheet(
+            host_stylesheet(
+                "color: #808080; font-size: 11px; font-weight: bold;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         header_layout.addWidget(self._label, 1)
 
         self._status_label = QLabel("")
-        self._status_label.setStyleSheet("color: #dcdcaa; font-size: 10px;")
+        self._status_label.setStyleSheet(
+            host_stylesheet(
+                "color: #dcdcaa; font-size: 10px;",
+                _native_text_style(size=10, bold=True),
+            )
+        )
         header_layout.addWidget(self._status_label)
 
         layout.addLayout(header_layout)
@@ -839,13 +959,28 @@ class ToolGroupWidget(QFrame):
             if self._errors:
                 ok = self._done - self._errors
                 self._status_label.setText(f"✓{ok} ✗{self._errors}")
-                self._status_label.setStyleSheet("color: #f44747; font-size: 10px;")
+                self._status_label.setStyleSheet(
+                    host_stylesheet(
+                        "color: #f44747; font-size: 10px;",
+                        _native_text_style(size=10, bold=True),
+                    )
+                )
             else:
                 self._status_label.setText("✓")
-                self._status_label.setStyleSheet("color: #4ec9b0; font-size: 10px;")
+                self._status_label.setStyleSheet(
+                    host_stylesheet(
+                        "color: #4ec9b0; font-size: 10px;",
+                        _native_text_style(size=10, bold=True),
+                    )
+                )
         else:
             self._status_label.setText(f"{self._done}/{self._count}")
-            self._status_label.setStyleSheet("color: #dcdcaa; font-size: 10px;")
+            self._status_label.setStyleSheet(
+                host_stylesheet(
+                    "color: #dcdcaa; font-size: 10px;",
+                    _native_text_style(size=10, bold=True),
+                )
+            )
 
     def _toggle(self) -> None:
         self._expanded = not self._expanded
@@ -988,7 +1123,10 @@ class ToolApprovalWidget(QFrame):
         self._approved_callback = None
         self.setObjectName("message_question")
         self.setStyleSheet(
-            "QFrame#message_question { border: 1px solid #dcdcaa; border-radius: 6px; background: #2d2d1e; }"
+            host_stylesheet(
+                "QFrame#message_question { border: 1px solid #dcdcaa; border-radius: 6px; background: #2d2d1e; }",
+                "QFrame#message_question { background: transparent; border: none; }",
+            )
         )
         self._tool_call_id = tool_call_id
 
@@ -996,14 +1134,24 @@ class ToolApprovalWidget(QFrame):
         layout.setContentsMargins(8, 6, 8, 6)
 
         self._header = QLabel("Approve execute_python?")
-        self._header.setStyleSheet("color: #dcdcaa; font-weight: bold; font-size: 11px;")
+        self._header.setStyleSheet(
+            host_stylesheet(
+                "color: #dcdcaa; font-weight: bold; font-size: 11px;",
+                _native_text_style(size=11, bold=True),
+            )
+        )
         layout.addWidget(self._header)
 
         code = self._extract_code(args_text)
         code_lines = code.strip().splitlines() if code.strip() else []
 
         self._info = QLabel(f"Python code — {len(code_lines)} line{'s' if len(code_lines) != 1 else ''}")
-        self._info.setStyleSheet("color: #808080; font-size: 10px;")
+        self._info.setStyleSheet(
+            host_stylesheet(
+                "color: #808080; font-size: 10px;",
+                _native_text_style(size=10),
+            )
+        )
         layout.addWidget(self._info)
 
         editor = self._build_code_editor(code, code_lines)
@@ -1032,22 +1180,25 @@ class ToolApprovalWidget(QFrame):
         self._code_edit.setReadOnly(True)
         self._code_edit.setPlainText(code)
         self._code_edit.setStyleSheet(
-            "QPlainTextEdit { "
-            "  color: #d4d4d4; background: #1e1e2e; "
-            "  font-family: 'Consolas', 'Monaco', 'Courier New', monospace; "
-            "  font-size: 11px; border: 1px solid #3c3c3c; border-radius: 4px; "
-            "  padding: 4px; "
-            "}"
-            "QScrollBar:vertical { width: 8px; background: #1e1e2e; }"
-            "QScrollBar::handle:vertical { background: #3c3c3c; border-radius: 4px; }"
-            "QScrollBar:horizontal { height: 8px; background: #1e1e2e; }"
-            "QScrollBar::handle:horizontal { background: #3c3c3c; border-radius: 4px; }"
+            host_stylesheet(
+                "QPlainTextEdit { "
+                "  color: #d4d4d4; background: #1e1e2e; "
+                "  font-family: 'Consolas', 'Monaco', 'Courier New', monospace; "
+                "  font-size: 11px; border: 1px solid #3c3c3c; border-radius: 4px; "
+                "  padding: 4px; "
+                "}"
+                "QScrollBar:vertical { width: 8px; background: #1e1e2e; }"
+                "QScrollBar::handle:vertical { background: #3c3c3c; border-radius: 4px; }"
+                "QScrollBar:horizontal { height: 8px; background: #1e1e2e; }"
+                "QScrollBar::handle:horizontal { background: #3c3c3c; border-radius: 4px; }"
+            )
         )
         self._code_edit.setLineWrapMode(QPlainTextEdit.LineWrapMode.NoWrap)
         visible_lines = min(len(lines), 15)
         line_height = self._code_edit.fontMetrics().lineSpacing()
         self._code_edit.setFixedHeight(line_height * visible_lines + 16)
-        self._highlighter = _PythonHighlighter(self._code_edit.document())
+        if not use_native_host_theme():
+            self._highlighter = _PythonHighlighter(self._code_edit.document())
         return self._code_edit
 
     def _build_approval_buttons(self) -> QHBoxLayout:
@@ -1058,9 +1209,11 @@ class ToolApprovalWidget(QFrame):
         self._allow_btn = QToolButton()
         self._allow_btn.setText("  Allow  ")
         self._allow_btn.setStyleSheet(
-            "QToolButton { background: #2ea043; color: #ffffff; border: none; "
-            "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
-            "QToolButton:hover { background: #3fb950; }"
+            host_stylesheet(
+                "QToolButton { background: #2ea043; color: #ffffff; border: none; "
+                "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
+                "QToolButton:hover { background: #3fb950; }"
+            )
         )
         self._allow_btn.clicked.connect(self._on_allow)
         btn_layout.addWidget(self._allow_btn)
@@ -1068,9 +1221,11 @@ class ToolApprovalWidget(QFrame):
         self._always_btn = QToolButton()
         self._always_btn.setText("  Always Allow  ")
         self._always_btn.setStyleSheet(
-            "QToolButton { background: #1a5c2d; color: #ffffff; border: none; "
-            "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
-            "QToolButton:hover { background: #2ea043; }"
+            host_stylesheet(
+                "QToolButton { background: #1a5c2d; color: #ffffff; border: none; "
+                "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
+                "QToolButton:hover { background: #2ea043; }"
+            )
         )
         self._always_btn.clicked.connect(self._on_always_allow)
         btn_layout.addWidget(self._always_btn)
@@ -1078,9 +1233,11 @@ class ToolApprovalWidget(QFrame):
         self._deny_btn = QToolButton()
         self._deny_btn.setText("  Deny  ")
         self._deny_btn.setStyleSheet(
-            "QToolButton { background: #c42b1c; color: #ffffff; border: none; "
-            "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
-            "QToolButton:hover { background: #e04030; }"
+            host_stylesheet(
+                "QToolButton { background: #c42b1c; color: #ffffff; border: none; "
+                "border-radius: 4px; padding: 4px 16px; font-size: 11px; font-weight: bold; }"
+                "QToolButton:hover { background: #e04030; }"
+            )
         )
         self._deny_btn.clicked.connect(self._on_deny)
         btn_layout.addWidget(self._deny_btn)
@@ -1097,8 +1254,10 @@ class ToolApprovalWidget(QFrame):
         self._disable_buttons()
         self._allow_btn.setText("  Allowed  ")
         self._allow_btn.setStyleSheet(
-            "QToolButton { background: #1a5c2d; color: #808080; border: none; "
-            "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
+            host_stylesheet(
+                "QToolButton { background: #1a5c2d; color: #808080; border: none; "
+                "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
+            )
         )
         if self._approved_callback is not None:
             self._approved_callback(self._tool_call_id, "allow")
@@ -1107,8 +1266,10 @@ class ToolApprovalWidget(QFrame):
         self._disable_buttons()
         self._always_btn.setText("  Always Allowed  ")
         self._always_btn.setStyleSheet(
-            "QToolButton { background: #1a5c2d; color: #808080; border: none; "
-            "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
+            host_stylesheet(
+                "QToolButton { background: #1a5c2d; color: #808080; border: none; "
+                "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
+            )
         )
         if self._approved_callback is not None:
             self._approved_callback(self._tool_call_id, "allow_all")
@@ -1117,8 +1278,10 @@ class ToolApprovalWidget(QFrame):
         self._disable_buttons()
         self._deny_btn.setText("  Denied  ")
         self._deny_btn.setStyleSheet(
-            "QToolButton { background: #6e1a12; color: #808080; border: none; "
-            "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
+            host_stylesheet(
+                "QToolButton { background: #6e1a12; color: #808080; border: none; "
+                "border-radius: 4px; padding: 4px 16px; font-size: 11px; }"
+            )
         )
         if self._approved_callback is not None:
             self._approved_callback(self._tool_call_id, "deny")

--- a/rikugan/ui/tools_panel.py
+++ b/rikugan/ui/tools_panel.py
@@ -5,7 +5,6 @@ Can be shown as an independent window (QDialog) or embedded in a layout.
 
 from __future__ import annotations
 
-from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QFrame,
     QHBoxLayout,
@@ -14,6 +13,7 @@ from .qt_compat import (
     QVBoxLayout,
     QWidget,
 )
+from .styles import maybe_host_stylesheet
 
 _HEADER_STYLE = "color: #d4d4d4; font-weight: bold; font-size: 12px;"
 

--- a/rikugan/ui/tools_panel.py
+++ b/rikugan/ui/tools_panel.py
@@ -5,6 +5,7 @@ Can be shown as an independent window (QDialog) or embedded in a layout.
 
 from __future__ import annotations
 
+from .styles import maybe_host_stylesheet
 from .qt_compat import (
     QFrame,
     QHBoxLayout,
@@ -58,7 +59,7 @@ class ToolsPanel(QWidget):
         super().__init__(parent)
         self.setObjectName("tools_panel")
         self.setWindowTitle("Rikugan Tools")
-        self.setStyleSheet(_PANEL_STYLE)
+        self.setStyleSheet(maybe_host_stylesheet(_PANEL_STYLE))
         # No minimum size — this widget is embedded in IDA dockable forms
         # and Binary Ninja sidebars, which can be any size.
 
@@ -73,7 +74,7 @@ class ToolsPanel(QWidget):
         header_layout.setContentsMargins(12, 8, 12, 8)
 
         title = QLabel("Tools")
-        title.setStyleSheet(_HEADER_STYLE)
+        title.setStyleSheet(maybe_host_stylesheet(_HEADER_STYLE))
         header_layout.addWidget(title)
         header_layout.addStretch()
 
@@ -85,12 +86,12 @@ class ToolsPanel(QWidget):
 
         # Placeholder tabs
         self._renamer_placeholder = QLabel("Not loaded")
-        self._renamer_placeholder.setStyleSheet("color: #808080; padding: 20px;")
+        self._renamer_placeholder.setStyleSheet(maybe_host_stylesheet("color: #808080; padding: 20px;"))
         self._renamer_placeholder.setWordWrap(True)
         self._tabs.addTab(self._renamer_placeholder, "Renamer")
 
         self._agents_placeholder = QLabel("Not loaded")
-        self._agents_placeholder.setStyleSheet("color: #808080; padding: 20px;")
+        self._agents_placeholder.setStyleSheet(maybe_host_stylesheet("color: #808080; padding: 20px;"))
         self._agents_placeholder.setWordWrap(True)
         self._tabs.addTab(self._agents_placeholder, "Agents")
 

--- a/rikugan_plugin.py
+++ b/rikugan_plugin.py
@@ -144,9 +144,17 @@ def _log(msg: str) -> None:
     """Best-effort log to IDA output and debug file."""
     idaapi.msg(f"[Rikugan] {msg}\n")
     try:
-        importlib.import_module("rikugan.core.logging").log_trace(msg)
-    except Exception as e:
-        import sys; sys.stderr.write(f"[Rikugan] log_trace unavailable during bootstrap: {e}\n")
+        logging_mod = importlib.import_module("rikugan.core.logging")
+        trace = getattr(logging_mod, "log_trace", None)
+        if callable(trace):
+            trace(msg)
+            return
+        debug = getattr(logging_mod, "log_debug", None)
+        if callable(debug):
+            debug(msg)
+    except Exception:
+        # Early bootstrap can observe partially initialized modules; ignore.
+        pass
 
 
 def PLUGIN_ENTRY():  # noqa: N802

--- a/tests/core/test_dependencies.py
+++ b/tests/core/test_dependencies.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from unittest.mock import patch
+
+from rikugan.core.dependencies import get_missing_dependency_warnings, get_optional_dependency_statuses
+
+
+class TestDependencies(unittest.TestCase):
+    def test_statuses_include_known_optional_packages(self):
+        statuses = get_optional_dependency_statuses()
+        keys = {status.key for status in statuses}
+        self.assertIn("anthropic", keys)
+        self.assertIn("openai", keys)
+        self.assertIn("gemini", keys)
+        self.assertIn("mcp", keys)
+
+    def test_missing_dependency_warnings_are_human_readable(self):
+        def fake_find_spec(name: str):
+            if name == "openai":
+                return None
+            return object()
+
+        with patch.object(importlib.util, "find_spec", side_effect=fake_find_spec):
+            warnings = get_missing_dependency_warnings()
+
+        self.assertTrue(any("openai" in warning.lower() for warning in warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/core/test_external_sources.py
+++ b/tests/core/test_external_sources.py
@@ -17,6 +17,9 @@ install_ida_mocks()
 from rikugan.core.external_sources import (
     get_claude_code_base,
     get_codex_base,
+    get_claude_skills_dir,
+    get_codex_skills_dir,
+    get_external_skills_title,
     discover_claude_skills,
     discover_codex_skills,
     discover_all_external_skills,
@@ -33,6 +36,9 @@ class TestPathResolution(unittest.TestCase):
     def test_claude_code_base(self):
         base = get_claude_code_base()
         self.assertEqual(base, Path.home() / ".claude")
+
+    def test_claude_skills_dir(self):
+        self.assertEqual(get_claude_skills_dir(), get_claude_code_base() / "skills")
 
     def test_codex_base_default(self):
         """Default codex base is ~/.codex."""
@@ -56,6 +62,27 @@ class TestPathResolution(unittest.TestCase):
         with patch.dict(os.environ, {"CODEX_HOME": ""}):
             base = get_codex_base()
             self.assertEqual(base, Path.home() / ".codex")
+
+    def test_codex_skills_dir(self):
+        with patch.dict(os.environ, {}, clear=False):
+            env = os.environ.copy()
+            env.pop("CODEX_HOME", None)
+            with patch.dict(os.environ, env, clear=True):
+                self.assertEqual(get_codex_skills_dir(), get_codex_base() / "skills")
+
+    def test_external_skills_title_claude(self):
+        with patch("rikugan.core.external_sources.get_claude_skills_dir", return_value=Path(r"C:\Users\Pyra\.claude\skills")):
+            self.assertEqual(
+                get_external_skills_title("claude"),
+                r"Claude Code Skills (C:\Users\Pyra\.claude\skills)",
+            )
+
+    def test_external_skills_title_codex(self):
+        with patch("rikugan.core.external_sources.get_codex_skills_dir", return_value=Path(r"C:\Users\Pyra\.codex\skills")):
+            self.assertEqual(
+                get_external_skills_title("codex"),
+                r"Codex Skills (C:\Users\Pyra\.codex\skills)",
+            )
 
 
 class TestManagedPaths(unittest.TestCase):

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 import os
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from tests.mocks.ida_mock import install_ida_mocks
@@ -82,6 +83,27 @@ class TestProviderRegistry(unittest.TestCase):
         reg = ProviderRegistry()
         with self.assertRaises(ProviderError):
             reg.create("nonexistent")
+
+    def test_dependency_warnings_returns_list(self):
+        reg = ProviderRegistry()
+        warnings = reg.dependency_warnings()
+        self.assertIsInstance(warnings, list)
+
+    def test_custom_provider_create_sets_provider_name(self):
+        reg = ProviderRegistry()
+        reg.register_custom_providers(["custom-endpoint"])
+
+        class FakeProvider:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.api_key = kwargs.get("api_key", "")
+                self.api_base = kwargs.get("api_base", "")
+                self.model = kwargs.get("model", "")
+
+        with patch.object(reg, "_resolve_provider_class", return_value=FakeProvider):
+            provider = reg.create("custom-endpoint", api_key="k", api_base="b", model="m")
+
+        self.assertEqual(provider.kwargs["provider_name"], "custom-endpoint")
 
 
 if __name__ == "__main__":

--- a/tests/qt_stubs.py
+++ b/tests/qt_stubs.py
@@ -84,6 +84,7 @@ _GUI_NAMES = [
     "QColor",
     "QFont",
     "QIntValidator",
+    "QPalette",
     "QSyntaxHighlighter",
     "QTextCharFormat",
 ]
@@ -111,6 +112,7 @@ def ensure_pyside6_stubs() -> None:
         _stub_mod(
             "PySide6.QtCore",
             Signal=_Signal,
+            QEvent=_qt_class("QEvent"),
             Qt=_sentinel,
             QObject=_qt_class("QObject"),
             QTimer=_qt_class("QTimer"),

--- a/tests/tools/test_input_area.py
+++ b/tests/tools/test_input_area.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import sys
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from tests.qt_stubs import ensure_pyside6_stubs
 ensure_pyside6_stubs()
+
+sys.modules.pop("rikugan.ui.input_area", None)
 
 from rikugan.ui.input_area import InputArea, _SkillPopup  # noqa: E402
 
@@ -93,6 +96,9 @@ def _make_input() -> InputArea:
     area._popup = None
     area._submit_callback = None
     area._cancel_callback = None
+    area._applying_theme = False
+    area._theme_css = ""
+    area.setStyleSheet = MagicMock()
     return area
 
 
@@ -168,6 +174,27 @@ class TestInputAreaCheckAutocomplete(unittest.TestCase):
         area.toPlainText = MagicMock(return_value="/xyz")
         area._check_autocomplete()
         area._dismiss_popup.assert_called_once()
+
+
+class TestInputAreaApplyTheme(unittest.TestCase):
+    def test_apply_theme_sets_stylesheet_and_caches_css(self):
+        area = _make_input()
+        css = "QPlainTextEdit#input_area { background-color: #222222; color: #eeeeee; }"
+        with patch("rikugan.ui.input_area.use_native_host_theme", return_value=True):
+            with patch("rikugan.ui.input_area.build_input_area_stylesheet", return_value=css):
+                area._apply_theme()
+        area.setStyleSheet.assert_called_once()
+        self.assertEqual(area._theme_css, css)
+        self.assertFalse(area._applying_theme)
+
+    def test_apply_theme_skips_when_css_is_unchanged(self):
+        area = _make_input()
+        expected_css = "QPlainTextEdit#input_area { background-color: #222222; color: #eeeeee; }"
+        area._theme_css = expected_css
+        with patch("rikugan.ui.input_area.use_native_host_theme", return_value=True):
+            with patch("rikugan.ui.input_area.build_input_area_stylesheet", return_value=expected_css):
+                area._apply_theme()
+        area.setStyleSheet.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_panel_core.py
+++ b/tests/tools/test_panel_core.py
@@ -30,9 +30,10 @@ for _mod_name in [
     if _mod_name not in sys.modules:
         _stub = types.ModuleType(_mod_name)
         for _attr in [
-            "DARK_THEME", "ChatView", "InputArea", "ContextBar",
+            "DARK_THEME", "build_theme_stylesheet", "maybe_host_stylesheet", "use_native_host_theme",
+            "ChatView", "InputArea", "ContextBar",
             "_SharedSpinnerTimer", "RikuganConfig",
-            "log_error", "log_info", "log_debug",
+            "log_error", "log_info", "log_debug", "log_warning",
             "TurnEvent", "TurnEventType", "MutationRecord",
             "Role", "ModelInfo",
             "resolve_auth_cached", "resolve_anthropic_auth",

--- a/tests/tools/test_settings_dialog.py
+++ b/tests/tools/test_settings_dialog.py
@@ -22,6 +22,7 @@ for _mod_name in [
     "rikugan.providers.auth_cache",
     "rikugan.providers.ollama_provider",
     "rikugan.providers.registry",
+    "rikugan.ui.styles",
 ]:
     _stub = types.ModuleType(_mod_name)
     for _attr in [
@@ -29,14 +30,25 @@ for _mod_name in [
         "log_debug",
         "log_error",
         "log_info",
+        "log_warning",
         "ModelInfo",
+        "Role",
         "resolve_anthropic_auth",
         "resolve_auth_cached",
         "DEFAULT_OLLAMA_URL",
         "ProviderRegistry",
+        "DARK_THEME",
+        "build_theme_stylesheet",
+        "maybe_host_stylesheet",
     ]:
         setattr(_stub, _attr, MagicMock())
     sys.modules[_mod_name] = _stub
+
+_styles_mod = sys.modules.get("rikugan.ui.styles")
+if _styles_mod is not None:
+    _styles_mod.maybe_host_stylesheet = lambda css: css
+    _styles_mod.build_theme_stylesheet = lambda: ""
+    _styles_mod.DARK_THEME = ""
 
 # Ensure DEFAULT_OLLAMA_URL is a string on the stub (real module already has it)
 _ollama_mod = sys.modules.get("rikugan.providers.ollama_provider")


### PR DESCRIPTION
## Changes

- installers now warn and continue when optional deps fail to install
- missing optional provider deps are detected at runtime and shown in the UI instead of breaking startup
- provider loading no longer eagerly imports optional SDKs
- `install.ps1` now falls back to ASCII when Unicode is not supported
- Rikugan now follows IDA’s native theme instead of forcing the dark stylesheet
- chat, tools, settings, and markdown/input rendering were updated to stop fighting the host theme
- fixed the `log_info` error when opening the Tools view
- Skills tab now shows the correct OS-specific external skill paths on Windows