### PR TITLE
allow larger context window limit for self-hosted providers

### DIFF
--- a/rikugan/providers/ollama_provider.py
+++ b/rikugan/providers/ollama_provider.py
@@ -46,8 +46,8 @@ class OllamaProvider(OpenAICompatProvider):
             streaming=True,
             tool_use=True,
             vision=False,
-            max_context_window=128000,
-            max_output_tokens=4096,
+            max_context_window=200000,
+            max_output_tokens=16384,
         )
 
     def list_models(self) -> list[ModelInfo]:

--- a/rikugan/providers/openai_compat.py
+++ b/rikugan/providers/openai_compat.py
@@ -57,8 +57,8 @@ class OpenAICompatProvider(OpenAIProvider):
             streaming=True,
             tool_use=True,
             vision=False,
-            max_context_window=128000,
-            max_output_tokens=4096,
+            max_context_window=200000,
+            max_output_tokens=16384,
         )
 
     def list_models(self) -> list[ModelInfo]:


### PR DESCRIPTION
Currently Ollama and OpenAI-compatible providers hard-limit `max_output_tokens` to 4096, a laughably small number compared to other providers. Since these providers are often used for self-hosted models, Rikugan should not add additional limit than what the model supports.

This PR increases output token limit to 16384 and context window limit to 200000, matching `DEFAULT_MAX_TOKENS` and `DEFAULT_CONTEXT_WINDOW` respectively.