### PR TITLE
Fix: Improve UI rendering performance

### DIFF
--- a/rikugan/ui/chat_view.py
+++ b/rikugan/ui/chat_view.py
@@ -443,6 +443,21 @@ class ChatView(QScrollArea):
         """Replay saved Message objects into the chat view."""
         self.clear_chat()
 
+        # Disable Qt layout/paint passes for the duration of the restore.
+        # Without this each _insert_widget call triggers a full O(n) layout
+        # recalculation on the growing container, making session restore
+        # O(n²) in the number of messages.
+        self._container.setUpdatesEnabled(False)
+        try:
+            self._restore_messages_inner(messages)
+        finally:
+            self._container.setUpdatesEnabled(True)
+
+        self._current_assistant = None
+        self._reset_tool_run()
+        self._scroll_to_bottom()
+
+    def _restore_messages_inner(self, messages: list[Message]) -> None:
         for msg in messages:
             if msg.role == Role.USER:
                 if _is_hidden_system_user_message(msg.content):
@@ -477,10 +492,6 @@ class ChatView(QScrollArea):
                     group = self._group_map.get(tr.tool_call_id)
                     if group:
                         group.notify_result(tr.is_error)
-
-        self._current_assistant = None
-        self._reset_tool_run()
-        self._scroll_to_bottom()
 
     def clear_chat(self) -> None:
         self._force_hide_thinking()

--- a/rikugan/ui/message_widgets.py
+++ b/rikugan/ui/message_widgets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import random
 import re as _re
+import time as _time
 from typing import ClassVar
 
 from .markdown import md_to_html
@@ -121,6 +122,38 @@ def _tool_frame_style(
 
 # Re-export tool widgets so existing consumers that import from this module
 # continue to work without changes.
+
+
+# ---------------------------------------------------------------------------
+# Height-caching QLabel — eliminates O(text_length) layout-pass cost
+# ---------------------------------------------------------------------------
+
+
+class _HeightCachedLabel(QLabel):
+    """QLabel that opts out of the layout heightForWidth protocol.
+
+    QLabel with wordWrap forces an O(text_length) heightForWidth() call on
+    every layout pass (e.g. when any sibling widget changes size).  In a chat
+    with many long assistant messages this makes tool expand/collapse and
+    parallel-tool completion O(N × msg_length) instead of O(N).
+
+    By returning False from hasHeightForWidth() and pinning the height after
+    each render, layout passes cost O(1) for this widget.  The correct height
+    is still computed — just once per render instead of on every layout event.
+    """
+
+    def hasHeightForWidth(self) -> bool:
+        return False
+
+    def pin_height(self) -> None:
+        """Fix widget height to the value heightForWidth returns for the current width."""
+        w = self.width()
+        if w <= 0:
+            return
+        h = QLabel.heightForWidth(self, w)
+        if h > 0:
+            self.setFixedHeight(h)
+
 
 # ---------------------------------------------------------------------------
 # Collapsible section (unchanged, used internally)
@@ -343,14 +376,21 @@ class _ThinkingBlock(QFrame):
 class AssistantMessageWidget(QFrame):
     """Displays an assistant message with streaming support and Markdown rendering."""
 
-    # Larger batch = fewer re-layouts during streaming = less shaking.
-    _RENDER_BATCH = 120
+    # Render at most every 100ms during streaming regardless of message length.
+    # This caps the O(n) md_to_html cost to ~10 fps as messages grow.
+    _RENDER_INTERVAL_S: float = 0.10
+    # Minimum pending chars before a time-gated render fires (avoids renders for tiny deltas).
+    _RENDER_BATCH_MIN: int = 30
+    # Unconditional render threshold — ensures we flush even when the interval
+    # hasn't elapsed (e.g. burst of 500+ chars in a single poll tick).
+    _RENDER_BATCH_MAX: int = 500
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
         self.setObjectName("message_assistant")
         self._full_text = ""
         self._pending_delta = 0
+        self._last_render_time: float = 0.0
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 6, 8, 6)
@@ -367,7 +407,7 @@ class AssistantMessageWidget(QFrame):
         self._thinking_block = _ThinkingBlock()
         layout.addWidget(self._thinking_block)
 
-        self._content = QLabel()
+        self._content = _HeightCachedLabel()
         self._content.setWordWrap(True)
         self._content.setTextFormat(Qt.TextFormat.RichText)
         self._content.setTextInteractionFlags(
@@ -403,11 +443,28 @@ class AssistantMessageWidget(QFrame):
             self._thinking_block.hide()
         self._content.setText(md_to_html(visible, self))
         self._pending_delta = 0
+        self._last_render_time = _time.monotonic()
+        self._content.pin_height()
+
+    def resizeEvent(self, event) -> None:
+        super().resizeEvent(event)
+        if event.size().width() != event.oldSize().width():
+            self._content.pin_height()
 
     def append_text(self, delta: str) -> None:
         self._full_text += delta
         self._pending_delta += len(delta)
-        if self._pending_delta >= self._RENDER_BATCH:
+        # Unconditional flush for very large bursts (prevents queue build-up).
+        if self._pending_delta >= self._RENDER_BATCH_MAX:
+            self._render()
+            return
+        # Time-gated render: fire once per interval when enough chars are pending.
+        # This caps md_to_html cost to ~10 fps regardless of how long the message
+        # has grown — avoids O(n²) total render work over a long response.
+        if (
+            self._pending_delta >= self._RENDER_BATCH_MIN
+            and _time.monotonic() - self._last_render_time >= self._RENDER_INTERVAL_S
+        ):
             self._render()
 
     def set_text(self, text: str) -> None:

--- a/rikugan/ui/message_widgets.py
+++ b/rikugan/ui/message_widgets.py
@@ -135,7 +135,7 @@ class _HeightCachedLabel(QLabel):
     QLabel with wordWrap forces an O(text_length) heightForWidth() call on
     every layout pass (e.g. when any sibling widget changes size).  In a chat
     with many long assistant messages this makes tool expand/collapse and
-    parallel-tool completion O(N × msg_length) instead of O(N).
+    parallel-tool completion O(N x msg_length) instead of O(N).
 
     By returning False from hasHeightForWidth() and pinning the height after
     each render, layout passes cost O(1) for this widget.  The correct height

--- a/rikugan/ui/panel_core.py
+++ b/rikugan/ui/panel_core.py
@@ -1035,13 +1035,26 @@ class RikuganPanelCore(QWidget):
             return
         self._polling = True
         try:
-            for _ in range(20):
-                event = self._ctrl.get_event(timeout=0)
-                if event is None:
-                    if not self._ctrl.is_agent_running:
-                        self._on_agent_finished()
-                    return
-                self._on_event(event)
+            chat_view = self._active_chat_view()
+            container = chat_view._container if chat_view is not None else None
+            # Defer layout/paint passes until the whole batch is processed.
+            # When 3 tools complete between ticks, each TOOL_RESULT makes a hidden
+            # widget visible which triggers an O(n-widgets) layout cascade on the
+            # chat container.  Batching those into one final pass cuts this from
+            # O(k·n) to O(n) per tick.
+            if container is not None:
+                container.setUpdatesEnabled(False)
+            try:
+                for _ in range(30):
+                    event = self._ctrl.get_event(timeout=0)
+                    if event is None:
+                        if not self._ctrl.is_agent_running:
+                            self._on_agent_finished()
+                        return
+                    self._on_event(event)
+            finally:
+                if container is not None:
+                    container.setUpdatesEnabled(True)
         finally:
             self._polling = False
 

--- a/rikugan/ui/tool_widgets.py
+++ b/rikugan/ui/tool_widgets.py
@@ -587,6 +587,7 @@ class ToolCallWidget(QFrame):
         self._args_label = QLabel()
         self._args_label.setObjectName("tool_content")
         self._args_label.setWordWrap(True)
+        self._args_label.setTextFormat(Qt.TextFormat.PlainText)
         self._args_label.setTextInteractionFlags(
             qt_flags(
                 Qt.TextInteractionFlag.TextSelectableByMouse,
@@ -608,6 +609,7 @@ class ToolCallWidget(QFrame):
         self._result_label = QLabel()
         self._result_label.setObjectName("tool_content")
         self._result_label.setWordWrap(True)
+        self._result_label.setTextFormat(Qt.TextFormat.PlainText)
         self._result_label.setTextInteractionFlags(
             qt_flags(
                 Qt.TextInteractionFlag.TextSelectableByMouse,
@@ -630,10 +632,12 @@ class ToolCallWidget(QFrame):
         _SharedSpinnerTimer.get().unregister(self)
 
     def _toggle(self) -> None:
+        self.setUpdatesEnabled(False)
         self._expanded = not self._expanded
         self._detail_widget.setVisible(self._expanded)
         self._preview_label.setVisible(not self._expanded and bool(self._args_text))
         self._toggle_btn.setText("\u25bc" if self._expanded else "\u25b6")
+        self.setUpdatesEnabled(True)
 
     def set_arguments(self, args_text: str) -> None:
         self._args_text = args_text
@@ -894,10 +898,12 @@ class ToolBatchWidget(QFrame):
             self._status_label.setText(f"{done}/{self._count}")
 
     def _toggle(self) -> None:
+        self.setUpdatesEnabled(False)
         self._expanded = not self._expanded
         self._detail_widget.setVisible(self._expanded)
         self._preview_label.setVisible(not self._expanded and bool(self._first_args))
         self._toggle_btn.setText("\u25bc" if self._expanded else "\u25b6")
+        self.setUpdatesEnabled(True)
 
     @property
     def tool_name(self) -> str:
@@ -1016,9 +1022,11 @@ class ToolGroupWidget(QFrame):
             )
 
     def _toggle(self) -> None:
+        self.setUpdatesEnabled(False)
         self._expanded = not self._expanded
         self._body.setVisible(self._expanded)
         self._toggle_btn.setText("\u25bc" if self._expanded else "\u25b6")
+        self.setUpdatesEnabled(True)
 
     @property
     def count(self) -> int:


### PR DESCRIPTION
Basically UI has rendering issues and it feels progressively laggy with larger and larger chats.  

When you also try to expand tool call to see output it takes 1-2 seconds to open it. With the fixes I see drastic ui performance improvements.

Patched by claude.