### PR TITLE
fix(codex): fetch models live on Windows; smooth chat streaming & scroll

### DIFF
--- a/ci-local.ps1
+++ b/ci-local.ps1
@@ -1,0 +1,182 @@
+# Local CI simulation for Windows - mirrors ci-local.sh / the GitHub Actions pipeline.
+# Usage: .\ci-local.ps1 [-Fix]
+#
+# Runs the same five gates as ci-local.sh: ruff format, ruff lint, mypy
+# (core + providers), pytest, and the desloppify objective-score gate.
+# Prefers `uv run --group dev` when uv is available (matching ci-local.sh);
+# otherwise falls back to pip-installed pinned tools + the system Python,
+# matching what GitHub Actions does.
+
+[CmdletBinding()]
+param(
+    [switch]$Fix
+)
+
+$ErrorActionPreference = "Continue"
+Set-Location -Path $PSScriptRoot
+
+$script:Pass = 0
+$script:Fail = 0
+$script:Results = @()
+
+function Write-Info($msg) { Write-Host "> $msg" -ForegroundColor Yellow }
+function Add-Ok($msg) { $script:Pass++; $script:Results += "  [PASS] $msg" }
+function Add-Fail($msg, $detail) { $script:Fail++; $script:Results += "  [FAIL] ${msg}: $detail" }
+function Add-Warn($msg) { $script:Results += "  [WARN] $msg" }
+
+# Run a Python module (ruff/mypy/pytest) through the active runner. The tool's
+# exit code is left in $LASTEXITCODE for the caller to inspect.
+function Invoke-Py {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+    if ($script:UseUv) { & uv run --group dev python @Args } else { & python @Args }
+}
+
+# Run the desloppify CLI through the active runner.
+function Invoke-Desloppify {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Args)
+    if ($script:UseUv) { & uv run --group dev desloppify @Args } else { & desloppify @Args }
+}
+
+# True if a Python module is importable/runnable under the active runner.
+function Test-PyModule([string[]]$ModuleArgs) {
+    Invoke-Py @ModuleArgs *> $null
+    return ($LASTEXITCODE -eq 0)
+}
+
+# -- Tool bootstrap ----------------------------------------------------------
+Write-Info "Checking tools..."
+
+$script:UseUv = [bool](Get-Command uv -ErrorAction SilentlyContinue)
+
+if (-not $script:UseUv) {
+    if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+        Write-Host "FAILED - no 'uv' and no 'python' on PATH" -ForegroundColor Red
+        exit 1
+    }
+    # Ensure pinned tool versions are present (mirrors the GitHub workflow).
+    $need = @()
+    if (-not (Test-PyModule @("-m", "ruff", "--version"))) { $need += "ruff==0.15.13" }
+    if (-not (Test-PyModule @("-m", "mypy", "--version"))) { $need += "mypy==2.1.0" }
+    if (-not (Test-PyModule @("-m", "pytest", "--version"))) { $need += "pytest==9.0.3" }
+    & desloppify --version *> $null
+    if ($LASTEXITCODE -ne 0) { $need += "desloppify==0.9.3" }
+    if ($need.Count -gt 0) {
+        Write-Host "  Installing missing tools: $($need -join ' ')"
+        & python -m pip install --quiet @need
+    }
+}
+
+# Verify ruff + mypy are reachable (hard requirement, as in ci-local.sh).
+if (-not (Test-PyModule @("-m", "ruff", "--version"))) {
+    Add-Fail "tool bootstrap" "ruff unavailable"
+    Write-Host "FAILED - $($script:Fail) check(s) failed, $($script:Pass) passed" -ForegroundColor Red
+    exit 1
+}
+if (-not (Test-PyModule @("-m", "mypy", "--version"))) {
+    Add-Fail "tool bootstrap" "mypy unavailable"
+    Write-Host "FAILED - $($script:Fail) check(s) failed, $($script:Pass) passed" -ForegroundColor Red
+    exit 1
+}
+
+$script:HavePytest = Test-PyModule @("-m", "pytest", "--version")
+if (-not $script:HavePytest) { Add-Warn "pytest: unavailable, skipped" }
+
+Invoke-Desloppify --version *> $null
+$script:HaveDesloppify = ($LASTEXITCODE -eq 0)
+if (-not $script:HaveDesloppify) { Add-Warn "desloppify: unavailable, skipped" }
+
+# -- 1. Ruff format ----------------------------------------------------------
+Write-Info "[1/5] Ruff format..."
+if ($Fix) {
+    Invoke-Py -m ruff format rikugan/
+    if ($LASTEXITCODE -eq 0) { Add-Ok "ruff format (auto-fixed)" } else { Add-Fail "ruff format" "failed" }
+}
+else {
+    Invoke-Py -m ruff format --check rikugan/
+    if ($LASTEXITCODE -eq 0) { Add-Ok "ruff format" } else { Add-Fail "ruff format" "run with -Fix to auto-fix" }
+}
+
+# -- 2. Ruff lint ------------------------------------------------------------
+Write-Info "[2/5] Ruff lint..."
+if ($Fix) {
+    Invoke-Py -m ruff check rikugan/ --fix
+    if ($LASTEXITCODE -eq 0) { Add-Ok "ruff lint (auto-fixed)" } else { Add-Fail "ruff lint" "see above" }
+}
+else {
+    Invoke-Py -m ruff check rikugan/
+    if ($LASTEXITCODE -eq 0) { Add-Ok "ruff lint" } else { Add-Fail "ruff lint" "see above" }
+}
+
+# -- 3. Mypy (core + providers) ----------------------------------------------
+Write-Info "[3/5] Mypy (core + providers)..."
+$mypyOut = Invoke-Py -m mypy rikugan/core rikugan/providers --pretty 2>&1 | Out-String
+if ($LASTEXITCODE -eq 0) {
+    Add-Ok "mypy"
+}
+else {
+    # Only count real errors, not informational notes.
+    $errorCount = ([regex]::Matches($mypyOut, '(?m): error:')).Count
+    if ($errorCount -gt 0) {
+        Write-Host $mypyOut
+        Add-Fail "mypy" "$errorCount error(s)"
+    }
+    else {
+        Add-Ok "mypy (warnings only)"
+    }
+}
+
+# -- 4. Pytest ---------------------------------------------------------------
+Write-Info "[4/5] Pytest..."
+if ($script:HavePytest) {
+    Invoke-Py -m pytest tests/ --tb=short -q
+    if ($LASTEXITCODE -eq 0) { Add-Ok "pytest" } else { Add-Fail "pytest" "see above" }
+}
+else {
+    Add-Warn "pytest: not installed, skipped"
+}
+
+# -- 5. Desloppify objective score gate --------------------------------------
+Write-Info "[5/5] Desloppify (objective score)..."
+if ($script:HaveDesloppify) {
+    Invoke-Desloppify scan --profile objective --no-badge 2>&1 | Select-Object -Last 5
+
+    $baseline = 89.0
+    $tolerance = 0.5
+    $score = 0.0
+    try {
+        $data = Get-Content ".desloppify/query.json" -Raw -ErrorAction Stop | ConvertFrom-Json
+        $score = [double]$data.objective_score
+    }
+    catch {
+        $score = 0.0
+    }
+
+    if ($score -lt ($baseline - $tolerance)) {
+        Add-Fail "desloppify" "objective score $score below baseline $baseline (tolerance $tolerance)"
+    }
+    else {
+        Add-Ok "desloppify (objective: $score/100, baseline: $baseline)"
+    }
+}
+else {
+    Add-Warn "desloppify: not found, skipped"
+}
+
+# -- Summary -----------------------------------------------------------------
+Write-Host ""
+Write-Host "-- CI Results --------------------------------------------" -ForegroundColor White
+foreach ($r in $script:Results) {
+    if ($r -like "*[PASS]*") { Write-Host $r -ForegroundColor Green }
+    elseif ($r -like "*[FAIL]*") { Write-Host $r -ForegroundColor Red }
+    else { Write-Host $r -ForegroundColor Yellow }
+}
+Write-Host ""
+
+if ($script:Fail -gt 0) {
+    Write-Host "FAILED - $($script:Fail) check(s) failed, $($script:Pass) passed" -ForegroundColor Red
+    exit 1
+}
+else {
+    Write-Host "ALL PASSED - $($script:Pass) checks" -ForegroundColor Green
+    exit 0
+}

--- a/rikugan/core/config.py
+++ b/rikugan/core/config.py
@@ -149,13 +149,13 @@ class RikuganConfig:
         else:
             d["encryption"] = {"enabled": False}
 
-        with open(self.config_path, "w") as f:
+        with open(self.config_path, "w", encoding="utf-8") as f:
             json.dump(d, f, indent=2)
 
     def load(self) -> None:
         if not os.path.exists(self.config_path):
             return
-        with open(self.config_path) as f:
+        with open(self.config_path, encoding="utf-8") as f:
             data = json.load(f)
         # Schema version check (for future migrations)
         _stored_version = data.pop("schema_version", 0)

--- a/rikugan/providers/codex_provider.py
+++ b/rikugan/providers/codex_provider.py
@@ -98,8 +98,8 @@ def _id_token_info(id_token: str) -> dict[str, Any]:
 def _codex_models_client_version() -> str:
     for path, key in ((_models_cache_path(), "client_version"), (_version_path(), "latest_version")):
         try:
-            value = json.loads(path.read_text()).get(key)
-        except (OSError, json.JSONDecodeError, AttributeError):
+            value = json.loads(path.read_text(encoding="utf-8")).get(key)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, AttributeError):
             continue
         if isinstance(value, str) and value:
             return value
@@ -220,7 +220,7 @@ def complete_codex_device_code_login(device_code: CodexDeviceCode, timeout_secon
 
 def codex_auth_status() -> tuple[str, str]:
     try:
-        auth = json.loads(_auth_path().read_text())
+        auth = json.loads(_auth_path().read_text(encoding="utf-8"))
         tokens = auth.get("tokens") or {}
         if (
             auth.get("auth_mode") == CODEX_AUTH_MODE
@@ -229,7 +229,7 @@ def codex_auth_status() -> tuple[str, str]:
             and tokens.get("refresh_token")
         ):
             return "ChatGPT OAuth", "ok"
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         pass
     return "Setup required", "error"
 
@@ -261,8 +261,8 @@ class CodexProvider(LLMProvider):
 
     def _load_auth(self) -> dict[str, Any]:
         try:
-            auth = json.loads(_auth_path().read_text())
-        except (OSError, json.JSONDecodeError) as exc:
+            auth = json.loads(_auth_path().read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise AuthenticationError(
                 "No Codex OAuth token found. Open settings and run Setup Codex.",
                 provider="codex",
@@ -386,13 +386,22 @@ class CodexProvider(LLMProvider):
             return None
         return parsed if parsed > 0 else None
 
+    def list_models(self) -> list[ModelInfo]:
+        """Always resolve the model list from the Codex upstream.
+
+        Codex model availability is account- and client-version-specific, so a
+        static fallback would misrepresent what the user can actually call.
+        Unlike the base implementation, failures are propagated to the caller
+        (e.g. the settings dialog) so they surface as an explicit error instead
+        of being masked behind placeholder models.
+        """
+        return self._fetch_models_live()
+
     @staticmethod
     def _builtin_models() -> list[ModelInfo]:
-        return [
-            ModelInfo("gpt-5.4", "GPT-5.4", "codex", 272000, 128000, True, True),
-            ModelInfo("gpt-5.2-codex", "GPT-5.2 Codex", "codex", 272000, 128000, True, True),
-            ModelInfo("gpt-5-codex", "GPT-5 Codex", "codex", 272000, 128000, True, True),
-        ]
+        # Codex has no offline defaults — see list_models(). The model list is
+        # always fetched live; if it doesn't arrive, the model is not available.
+        return []
 
     def _format_messages(self, messages: list[Message]) -> list[dict[str, Any]]:
         items: list[dict[str, Any]] = []

--- a/rikugan/state/history.py
+++ b/rikugan/state/history.py
@@ -74,10 +74,10 @@ class SessionHistory:
             data["subagent_logs"] = {key: [m.to_dict() for m in msgs] for key, msgs in session.subagent_logs.items()}
         if description:
             data["description"] = description
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
         summary_path = self._summary_path(session.id)
-        with open(summary_path, "w") as f:
+        with open(summary_path, "w", encoding="utf-8") as f:
             json.dump(_build_summary_data(data, session.id), f, indent=2)
         return path
 
@@ -87,9 +87,9 @@ class SessionHistory:
         if not os.path.exists(path):
             return None
         try:
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 data = json.load(f)
-        except (json.JSONDecodeError, OSError) as exc:
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
             log_debug(f"Failed to load session {session_id}: {exc}")
             return None
         session = SessionState(
@@ -117,7 +117,7 @@ class SessionHistory:
                 continue
             path = os.path.join(self._dir, fname)
             try:
-                with open(path) as f:
+                with open(path, encoding="utf-8") as f:
                     entry = json.load(f)
                 # When db_instance_id is provided, use it as the primary key
                 # (UUIDs are globally unique, so path matching is redundant).
@@ -134,7 +134,7 @@ class SessionHistory:
                     if entry["idb_path"]:
                         continue
                 sessions.append(entry)
-            except (json.JSONDecodeError, OSError, KeyError) as exc:
+            except (json.JSONDecodeError, UnicodeDecodeError, OSError, KeyError) as exc:
                 log_debug(f"Skipping corrupt session summary {fname}: {exc}")
                 continue
         return sessions

--- a/rikugan/ui/chat_view.py
+++ b/rikugan/ui/chat_view.py
@@ -90,6 +90,13 @@ class ChatView(QScrollArea):
         self._scroll_timer.setSingleShot(True)
         self._scroll_timer.setInterval(80)
         self._scroll_timer.timeout.connect(self._do_scroll)
+        # Auto-scroll "follow" intent. Streaming only sticks to the bottom while
+        # this is True; the user's own scrolling toggles it (scroll up to read
+        # history -> stop following; scroll back to the bottom -> resume).
+        self._follow_bottom = True
+        self._pending_force = False
+        self._programmatic_scroll = False
+        self.verticalScrollBar().valueChanged.connect(self._on_scroll_value_changed)
 
         # Timer for minimum thinking display duration (500ms)
         self._thinking_hide_timer = QTimer(self)
@@ -110,6 +117,10 @@ class ChatView(QScrollArea):
         widget = UserMessageWidget(text, parent=self._container)
         self._insert_widget(widget)
         self._current_assistant = None
+        # Sending is an explicit action — always jump to the bottom, even if the
+        # user had scrolled up (and even though inserting this message grows the
+        # content enough that the near-bottom heuristic would otherwise fail).
+        self._scroll_to_bottom(force=True)
 
     def add_error_message(self, text: str) -> None:
         self._insert_widget(ErrorMessageWidget(text, parent=self._container))
@@ -117,7 +128,7 @@ class ChatView(QScrollArea):
 
     def add_queued_message(self, text: str) -> None:
         self._insert_widget(QueuedMessageWidget(text, parent=self._container))
-        self._scroll_to_bottom()
+        self._scroll_to_bottom(force=True)
 
     def remove_queued_messages(self) -> None:
         """Remove all [queued] message widgets (e.g. on cancel)."""
@@ -263,6 +274,8 @@ class ChatView(QScrollArea):
         if event.type == TurnEventType.TEXT_DELTA:
             if self._current_assistant is None:
                 self._current_assistant = AssistantMessageWidget(parent=self._container)
+                # Follow the typewriter reveal, which renders between deltas.
+                self._current_assistant.set_render_callback(self._scroll_to_bottom)
                 self._insert_widget(self._current_assistant)
             self._current_assistant.append_text(event.text)
             self._scroll_to_bottom()
@@ -530,18 +543,48 @@ class ChatView(QScrollArea):
         if self._container is not None:
             self._container.setFixedWidth(self.viewport().width())
 
-    def _is_near_bottom(self) -> bool:
-        """True if the user hasn't scrolled up (within ~60px of bottom)."""
-        sb = self.verticalScrollBar()
-        return sb.maximum() - sb.value() < 60
+    def _on_scroll_value_changed(self, value: int) -> None:
+        """Track the user's follow intent from their own scrolling.
 
-    def _scroll_to_bottom(self) -> None:
-        if self._is_near_bottom():
+        Programmatic scrolls (our own ``_do_scroll``) are ignored; only a user
+        moving the scrollbar updates whether we should keep sticking to bottom.
+        """
+        if self._programmatic_scroll:
+            return
+        sb = self.verticalScrollBar()
+        self._follow_bottom = (sb.maximum() - value) <= 16
+
+    def _scroll_to_bottom(self, force: bool = False) -> None:
+        if force:
+            # Explicit user action (send/queue): re-arm follow and pin to bottom.
+            self._follow_bottom = True
+            self._pending_force = True
+            self._scroll_timer.start()
+        elif self._follow_bottom:
             self._scroll_timer.start()
 
+    def _set_scroll_value_silently(self, value: int) -> None:
+        """setValue without it being read back as a user scroll."""
+        self._programmatic_scroll = True
+        try:
+            self.verticalScrollBar().setValue(value)
+        finally:
+            self._programmatic_scroll = False
+
     def _do_scroll(self) -> None:
+        force = self._pending_force
+        self._pending_force = False
+        # Re-check at fire time: the user may have scrolled up during the 80ms
+        # coalescing window, in which case a non-forced scroll must not yank
+        # them back down.
+        if not force and not self._follow_bottom:
+            return
         sb = self.verticalScrollBar()
-        sb.setValue(sb.maximum())
+        self._set_scroll_value_silently(sb.maximum())
+        if force:
+            # The just-inserted widget may not be laid out yet, so maximum() can
+            # be stale; re-assert once the pending layout pass completes.
+            QTimer.singleShot(0, lambda: self._set_scroll_value_silently(self.verticalScrollBar().maximum()))
 
     def shutdown(self) -> None:
         self._scroll_timer.stop()

--- a/rikugan/ui/markdown.py
+++ b/rikugan/ui/markdown.py
@@ -27,6 +27,15 @@ _MARKDOWN_HINT_RE = re.compile(
 )
 
 
+def resolve_markdown_theme(source=None) -> dict[str, str]:
+    """Public wrapper around the markdown style resolution.
+
+    Callers that render repeatedly (streaming message widgets) resolve this
+    once and pass the result to ``md_to_html`` to avoid per-frame palette work.
+    """
+    return _theme_markdown_styles(source)
+
+
 def _theme_markdown_styles(source=None) -> dict[str, str]:
     colors = get_chat_color_tokens(source)
     code_bg = colors["code_bg"]
@@ -56,11 +65,17 @@ def _has_markdown_syntax(text: str) -> bool:
     return bool(text and _MARKDOWN_HINT_RE.search(text))
 
 
-def md_to_html(text: str, source=None) -> str:
-    """Convert a Markdown string to Qt-compatible HTML."""
+def md_to_html(text: str, source=None, theme: dict[str, str] | None = None) -> str:
+    """Convert a Markdown string to Qt-compatible HTML.
+
+    ``theme`` may be a pre-resolved style dict (see ``_theme_markdown_styles``)
+    to skip palette resolution.  Streaming widgets pass a cached theme so the
+    per-frame render cost doesn't include re-reading the host palette and
+    re-blending colors on every delta.
+    """
     if not text:
         return ""
-    theme = _theme_markdown_styles(source)
+    theme = theme or _theme_markdown_styles(source)
     if not _has_markdown_syntax(text):
         escaped = html.escape(text).replace("\n", "<br>")
         return re.sub(r"(<br>\s*){3,}", "<br><br>", escaped)

--- a/rikugan/ui/message_widgets.py
+++ b/rikugan/ui/message_widgets.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import random
 import re as _re
-import time as _time
 from typing import ClassVar
 
-from .markdown import md_to_html
+from .markdown import md_to_html, resolve_markdown_theme
 from .qt_compat import (
     QFrame,
     QHBoxLayout,
@@ -400,6 +399,7 @@ class _ThinkingBlock(QFrame):
         layout.addWidget(self._content)
 
         self._expanded = False
+        self._md_theme: dict[str, str] | None = None
         self.hide()
 
     def _on_toggle(self) -> None:
@@ -408,7 +408,9 @@ class _ThinkingBlock(QFrame):
         self._toggle.setText("\u25bc" if self._expanded else "\u25b6")
 
     def set_thinking(self, text: str, in_progress: bool = False) -> None:
-        self._content.setText(md_to_html(text, self))
+        if self._md_theme is None:
+            self._md_theme = resolve_markdown_theme(self)
+        self._content.setText(md_to_html(text, self, theme=self._md_theme))
         label = "Thinking\u2026" if in_progress else "Thinking"
         self._header_label.setText(label)
         self.show()
@@ -419,24 +421,81 @@ class _ThinkingBlock(QFrame):
 # ---------------------------------------------------------------------------
 
 
-class AssistantMessageWidget(QFrame):
-    """Displays an assistant message with streaming support and Markdown rendering."""
+def _commit_index_in_tail(tail: str) -> int:
+    """Return how many leading chars of *tail* form complete Markdown blocks.
 
-    # Render at most every 100ms during streaming regardless of message length.
-    # This caps the O(n) md_to_html cost to ~10 fps as messages grow.
-    _RENDER_INTERVAL_S: float = 0.10
-    # Minimum pending chars before a time-gated render fires (avoids renders for tiny deltas).
-    _RENDER_BATCH_MIN: int = 30
-    # Unconditional render threshold — ensures we flush even when the interval
-    # hasn't elapsed (e.g. burst of 500+ chars in a single poll tick).
-    _RENDER_BATCH_MAX: int = 500
+    A safe commit point is a paragraph break (``\\n\\n``) that is not inside an
+    open code fence.  ``tail`` is assumed to start at a block boundary with a
+    *closed* fence state (guaranteed by the caller, which only commits whole
+    blocks).  Uses ``str.find`` jumps so the scan is cheap even for code blocks.
+    """
+    in_fence = False
+    pos = 0
+    last = 0
+    n = len(tail)
+    while pos < n:
+        fence = tail.find("```", pos)
+        if not in_fence:
+            limit = fence if fence != -1 else n
+            nn = tail.find("\n\n", pos, limit)
+            if nn != -1:
+                pos = last = nn + 2
+                continue
+            if fence == -1:
+                break
+            in_fence = True
+            pos = fence + 3
+        else:
+            if fence == -1:
+                break  # unterminated fence — keep it in the live tail
+            in_fence = False
+            pos = fence + 3
+    return last
+
+
+class AssistantMessageWidget(QFrame):
+    """Displays an assistant message with streaming support and Markdown rendering.
+
+    Streaming is kept smooth on three fronts so per-frame cost stays O(tail)
+    instead of O(message) — even for long answers:
+
+    * **Display buffer (typewriter):** incoming deltas accumulate in
+      ``_full_text`` while a ``_reveal_timer`` reveals them at a steady cadence,
+      so bursty network arrival doesn't produce jumpy output.  The reveal rate
+      catches up to the buffer so it never lags behind the model.
+    * **Committed/tail split (two labels):** finalized Markdown blocks render
+      once into ``_committed_label`` and are never re-parsed or re-laid-out;
+      only the small in-progress *tail* is re-rendered into ``_tail_label`` each
+      frame.  This bounds both the Markdown parse *and* the Qt rich-text layout
+      to the tail.  On finalize everything collapses into the committed label so
+      the message is a single selectable block.
+    * **Thinking fast-path:** the ``<think>`` regex split only runs when a
+      ``<think>`` tag is actually present (the common case skips it).
+    """
+
+    # Reveal cadence for the typewriter buffer (~33 fps).
+    _REVEAL_INTERVAL_MS: int = 30
+    # Reveal at least this many chars per tick so short tails still animate.
+    _REVEAL_MIN_CHARS: int = 3
+    # Drain a fraction of the backlog each tick so large bursts catch up fast
+    # without snapping (remaining // divisor chars per tick).
+    _REVEAL_CATCHUP_DIVISOR: int = 3
 
     def __init__(self, parent: QWidget = None):
         super().__init__(parent)
         self.setObjectName("message_assistant")
         self._full_text = ""
-        self._pending_delta = 0
-        self._last_render_time: float = 0.0
+        self._displayed_len = 0
+        # Incrementally rendered HTML for finalized visible blocks (B2).
+        self._committed_html = ""
+        self._committed_visible_len = 0
+        # Resolve the markdown theme once; reuse it on every streaming frame so
+        # render cost excludes palette reads and color blends. The host theme is
+        # effectively constant for a message's lifetime.
+        self._md_theme: dict[str, str] | None = None
+        # Optional callback fired after each render so the parent can follow the
+        # typewriter reveal (which happens between delta arrivals).
+        self._render_callback = None
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(8, 6, 8, 6)
@@ -453,71 +512,157 @@ class AssistantMessageWidget(QFrame):
         self._thinking_block = _ThinkingBlock()
         layout.addWidget(self._thinking_block)
 
+        # The bubble is a frame carrying the surface (bg/border/radius); the
+        # committed and tail labels live inside it with transparent backgrounds
+        # so the two stacked labels read as one continuous bubble.
         bubble = _assistant_bubble_theme(self)
-        self._content = _HeightCachedLabel()
-        self._content.setWordWrap(True)
-        self._content.setTextFormat(Qt.TextFormat.RichText)
-        self._content.setTextInteractionFlags(
+        self._bubble = QFrame()
+        self._bubble.setObjectName("message_assistant_bubble")
+        self._bubble.setStyleSheet(
+            f"QFrame#message_assistant_bubble {{ {_frame_css(background=bubble['background'], border=bubble['border'], radius=10)} }}"
+        )
+        bubble_layout = QVBoxLayout(self._bubble)
+        bubble_layout.setContentsMargins(12, 8, 12, 8)  # emulates bubble padding
+        bubble_layout.setSpacing(0)
+
+        self._committed_label = self._make_content_label(bubble["text"])
+        self._committed_label.hide()
+        bubble_layout.addWidget(self._committed_label)
+        self._tail_label = self._make_content_label(bubble["text"])
+        bubble_layout.addWidget(self._tail_label)
+
+        self._bubble.setMinimumWidth(0)
+        self._bubble.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
+        layout.addWidget(self._bubble)
+
+        self._reveal_timer = QTimer(self)
+        self._reveal_timer.setInterval(self._REVEAL_INTERVAL_MS)
+        self._reveal_timer.timeout.connect(self._reveal_tick)
+
+    @staticmethod
+    def _make_content_label(text_color: str) -> _HeightCachedLabel:
+        label = _HeightCachedLabel()
+        label.setWordWrap(True)
+        label.setTextFormat(Qt.TextFormat.RichText)
+        label.setTextInteractionFlags(
             qt_flags(
                 Qt.TextInteractionFlag.TextSelectableByMouse,
                 Qt.TextInteractionFlag.TextSelectableByKeyboard,
                 Qt.TextInteractionFlag.LinksAccessibleByMouse,
             )
         )
-        self._content.setOpenExternalLinks(True)
-        self._content.setStyleSheet(
-            _bubble_css(
-                background=bubble["background"],
-                text_color=bubble["text"],
-                border=bubble["border"],
-            )
-        )
-        # Prevent the label from requesting more width than its parent
-        self._content.setMinimumWidth(0)
-        self._content.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
-        layout.addWidget(self._content)
+        label.setOpenExternalLinks(True)
+        label.setStyleSheet(f"background: transparent; color: {text_color}; font-size: 13px;")
+        label.setMinimumWidth(0)
+        label.setSizePolicy(QSizePolicy.Policy.Ignored, QSizePolicy.Policy.Preferred)
+        return label
 
-    def _render(self) -> None:
-        thinking, visible = _split_thinking(self._full_text)
+    def set_render_callback(self, callback) -> None:
+        """Register a callback fired after each render (e.g. scroll-to-bottom)."""
+        self._render_callback = callback
+
+    def _md_theme_cached(self) -> dict[str, str]:
+        if self._md_theme is None:
+            self._md_theme = resolve_markdown_theme(self)
+        return self._md_theme
+
+    def _update_thinking(self, text: str) -> str:
+        """Sync the thinking block from *text*; return the visible portion.
+
+        Fast-path: the ``<think>`` regex split only runs when a tag is present,
+        so the common (no-reasoning) case avoids an O(n) scan per frame.
+        """
+        if "<think>" not in text:
+            self._thinking_block.hide()
+            return text
+        thinking, visible = _split_thinking(text)
         if thinking:
-            in_progress = "<think>" in self._full_text and "</think>" not in self._full_text
+            in_progress = "</think>" not in text
             self._thinking_block.set_thinking(thinking, in_progress=in_progress)
         else:
             self._thinking_block.hide()
-        self._content.setText(md_to_html(visible, self))
-        self._pending_delta = 0
-        self._last_render_time = _time.monotonic()
-        self._content.pin_height()
+        return visible
+
+    def _render_progressive(self) -> None:
+        """Render the revealed text, re-parsing/laying out only the tail."""
+        theme = self._md_theme_cached()
+        visible = self._update_thinking(self._full_text[: self._displayed_len])
+
+        # Visible text is append-only in practice; reset defensively if it shrank
+        # (e.g. a <think> block resolving) so the committed prefix stays valid.
+        if self._committed_visible_len > len(visible):
+            self._committed_html = ""
+            self._committed_visible_len = 0
+            self._committed_label.clear()
+            self._committed_label.hide()
+
+        tail = visible[self._committed_visible_len :]
+        commit = _commit_index_in_tail(tail)
+        if commit > 0:
+            segment = tail[:commit]
+            self._committed_html += md_to_html(segment, self, theme=theme) + "<br>"
+            self._committed_visible_len += commit
+            tail = visible[self._committed_visible_len :]
+            # Committed label changes only when a block finalizes (infrequent),
+            # so its layout cost is paid once per block, not per frame.
+            self._committed_label.setText(self._committed_html)
+            self._committed_label.show()
+            self._committed_label.pin_height()
+
+        self._tail_label.setText(md_to_html(tail, self, theme=theme))
+        self._tail_label.setVisible(bool(tail))
+        self._tail_label.pin_height()
+        if self._render_callback is not None:
+            self._render_callback()
+
+    def _render_full(self) -> None:
+        """Render the entire message into the committed label (finalize/restore)."""
+        theme = self._md_theme_cached()
+        visible = self._update_thinking(self._full_text)
+        self._committed_label.setText(md_to_html(visible, self, theme=theme))
+        self._committed_label.show()
+        self._committed_label.pin_height()
+        self._tail_label.clear()
+        self._tail_label.hide()
+
+    def _reveal_tick(self) -> None:
+        remaining = len(self._full_text) - self._displayed_len
+        if remaining <= 0:
+            self._reveal_timer.stop()
+            return
+        step = max(self._REVEAL_MIN_CHARS, remaining // self._REVEAL_CATCHUP_DIVISOR)
+        self._displayed_len = min(len(self._full_text), self._displayed_len + step)
+        self._render_progressive()
+        if self._displayed_len >= len(self._full_text):
+            self._reveal_timer.stop()
 
     def resizeEvent(self, event) -> None:
         super().resizeEvent(event)
         if event.size().width() != event.oldSize().width():
-            self._content.pin_height()
+            self._committed_label.pin_height()
+            self._tail_label.pin_height()
 
     def append_text(self, delta: str) -> None:
         self._full_text += delta
-        self._pending_delta += len(delta)
-        # Unconditional flush for very large bursts (prevents queue build-up).
-        if self._pending_delta >= self._RENDER_BATCH_MAX:
-            self._render()
-            return
-        # Time-gated render: fire once per interval when enough chars are pending.
-        # This caps md_to_html cost to ~10 fps regardless of how long the message
-        # has grown — avoids O(n²) total render work over a long response.
-        if (
-            self._pending_delta >= self._RENDER_BATCH_MIN
-            and _time.monotonic() - self._last_render_time >= self._RENDER_INTERVAL_S
-        ):
-            self._render()
+        # Drive rendering from the reveal timer rather than the arrival cadence,
+        # so a burst of deltas animates smoothly instead of jumping.
+        if not self._reveal_timer.isActive():
+            self._reveal_timer.start()
 
     def set_text(self, text: str) -> None:
+        # Finalize/restore: snap to the authoritative full render so nothing is
+        # left half-revealed and the committed/tail split can't drift.
+        self._reveal_timer.stop()
         self._full_text = text
-        self._render()
+        self._displayed_len = len(text)
+        self._committed_html = ""
+        self._committed_visible_len = 0
+        self._render_full()
         # During session restore, setUpdatesEnabled(False) is active when this
         # is called, so the widget has no width yet and pin_height() returns
         # early. Schedule a deferred call so it re-pins after the layout pass.
-        if self._content.width() <= 0:
-            QTimer.singleShot(0, self._content.pin_height)
+        if self._committed_label.width() <= 0:
+            QTimer.singleShot(0, self._committed_label.pin_height)
 
     def full_text(self) -> str:
         return self._full_text

--- a/rikugan/ui/panel_core.py
+++ b/rikugan/ui/panel_core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import queue
 import re
 import threading
 import time
@@ -637,6 +638,8 @@ class RikuganPanelCore(QWidget):
         self._context_bar: ContextBar | None = None
         self._mutation_panel: MutationLogPanel | None = None
         self._skills_refresh_timer: QTimer | None = None
+        self._restore_timer: QTimer | None = None
+        self._restore_queue: queue.Queue | None = None
 
         self._check_oauth_consent()
 
@@ -1256,6 +1259,7 @@ class RikuganPanelCore(QWidget):
             tools_panel = getattr(self, "_tools_panel", None)
             self._stop_poll_timer()
             self._stop_skills_refresh_timer()
+            self._stop_restore_poll_timer()
             _SharedSpinnerTimer.shutdown()
             if self._context_bar:
                 self._context_bar.stop()
@@ -1564,12 +1568,73 @@ class RikuganPanelCore(QWidget):
         self._set_running(False, tab_id=tab_id)
 
     def _try_restore_session(self) -> None:
-        restored = self._ctrl.restore_sessions()
+        """Kick off session restore without blocking first paint.
+
+        The heavy work — reading and parsing every saved chat from disk — runs
+        on a background thread.  When it finishes, a poll timer builds the tabs
+        back on the UI thread (Qt widgets must not be created off-thread).
+        """
+        if not self._config.restore_sessions_on_start:
+            return
+        # Cancel any in-flight restore (e.g. a rapid database switch).
+        self._stop_restore_poll_timer()
+        result_queue: queue.Queue = queue.Queue()
+        self._restore_queue = result_queue
+
+        def _load() -> None:
+            try:
+                sessions = self._ctrl.load_restorable_sessions()
+            except Exception as e:  # defensive: never let the thread die silently
+                log_error(f"Session restore load failed: {e}")
+                sessions = []
+            result_queue.put(sessions)
+
+        threading.Thread(target=_load, daemon=True, name="rikugan-session-restore").start()
+        self._ensure_restore_poll_timer()
+
+    def _ensure_restore_poll_timer(self) -> None:
+        if self._restore_timer is not None:
+            return
+        self._restore_timer = QTimer(self)
+        self._restore_timer.setInterval(40)
+        self._restore_timer.timeout.connect(self._poll_restore)
+        self._restore_timer.start()
+
+    def _stop_restore_poll_timer(self) -> None:
+        if self._restore_timer is None:
+            return
+        self._restore_timer.stop()
+        try:
+            self._restore_timer.timeout.disconnect(self._poll_restore)
+        except (RuntimeError, TypeError) as e:
+            log_debug(f"restore timer disconnect failed: {e}")
+        self._restore_timer.deleteLater()
+        self._restore_timer = None
+
+    def _poll_restore(self) -> None:
+        if self._is_shutdown:
+            self._stop_restore_poll_timer()
+            return
+        if self._restore_queue is None:
+            self._stop_restore_poll_timer()
+            return
+        try:
+            sessions = self._restore_queue.get_nowait()
+        except queue.Empty:
+            return
+        self._stop_restore_poll_timer()
+        self._restore_queue = None
+        self._apply_restored_sessions(sessions)
+
+    def _apply_restored_sessions(self, sessions: list) -> None:
+        """Register pre-loaded sessions and build their tabs (UI thread)."""
+        if self._is_shutdown:
+            return
+        restored = self._ctrl.register_restored_sessions(sessions)
         if restored:
-            # Remove the default empty tab if it was replaced
+            # Remove the default empty tab if registration dropped it.
             for tid, cv in list(self._chat_views.items()):
                 if tid not in self._ctrl.tab_ids:
-                    # This tab was removed during restore
                     for i in range(self._tab_widget.count()):
                         if self._tab_widget.widget(i) is cv:
                             self._tab_widget.removeTab(i)
@@ -1583,19 +1648,20 @@ class RikuganPanelCore(QWidget):
                 self._pending_restore_messages[tab_id] = session.messages
                 self._create_tab(tab_id, label)
 
-            # Activate the last (most recent) tab
-            if restored:
-                last_tab_id = restored[-1][0]
-                last_cv = self._chat_views.get(last_tab_id)
-                if last_cv:
-                    for i in range(self._tab_widget.count()):
-                        if self._tab_widget.widget(i) is last_cv:
-                            self._tab_widget.setCurrentIndex(i)
-                            break
-                    self._restore_messages_if_needed(last_tab_id)
-                self._update_token_display()
+            # Align the visible tab with the controller's active tab (which
+            # only moved if the default empty tab was dropped).
+            active = self._ctrl.active_tab_id
+            active_cv = self._chat_views.get(active)
+            if active_cv is not None:
+                for i in range(self._tab_widget.count()):
+                    if self._tab_widget.widget(i) is active_cv:
+                        self._tab_widget.setCurrentIndex(i)
+                        break
+                self._restore_messages_if_needed(active)
+            self._update_token_display()
         else:
-            # No saved sessions — try legacy single-session restore
+            # No multi-session history — try legacy single-session restore
+            # (at most one session, cheap enough on the UI thread).
             session = self._ctrl.restore_session()
             if session:
                 legacy_cv = self._active_chat_view()

--- a/rikugan/ui/session_controller_base.py
+++ b/rikugan/ui/session_controller_base.py
@@ -430,15 +430,23 @@ class SessionControllerBase:
         elif self._active_tab_id == tab_id:
             self._active_tab_id = next(iter(self._sessions))
 
-    def restore_sessions(self) -> list[tuple[str, SessionState]]:
-        """Load ALL saved sessions for the current idb_path and return (tab_id, session) pairs."""
-        results: list[tuple[str, SessionState]] = []
+    def load_restorable_sessions(self) -> list[SessionState]:
+        """Read and parse all saved sessions for the current database from disk.
+
+        Pure data path — performs only disk I/O and JSON/Message parsing and
+        does NOT touch ``self._sessions`` or create any Qt objects, so it is
+        safe to run on a background thread.  The expensive part of restore
+        (parsing every message of every chat) lives here; tab registration and
+        widget creation happen later on the UI thread via
+        ``register_restored_sessions``.  Sessions are returned oldest-first.
+        """
+        loaded: list[SessionState] = []
         if not self.config.restore_sessions_on_start:
             log_debug("Skipping session restore: disabled in config")
-            return results
+            return loaded
         if not self._idb_path:
             log_debug("Skipping session restore: no database path available")
-            return results
+            return loaded
         try:
             history = SessionHistory(self.config)
             summaries = history.list_sessions(
@@ -449,21 +457,47 @@ class SessionControllerBase:
             for summary in summaries:
                 session = history.load_session(summary["id"])
                 if session and session.messages:
-                    tab_id = uuid.uuid4().hex[:8]
-                    self._sessions[tab_id] = session
-                    results.append((tab_id, session))
-                    log_debug(f"Restored session {session.id} as tab {tab_id}")
+                    loaded.append(session)
         except (OSError, ValueError, KeyError) as e:
-            log_error(f"Failed to restore sessions: {e}")
+            log_error(f"Failed to load sessions for restore: {e}")
+        return loaded
+
+    def register_restored_sessions(self, sessions: list[SessionState]) -> list[tuple[str, SessionState]]:
+        """Register pre-loaded sessions as tabs. Must run on the UI thread.
+
+        Assigns tab ids, inserts them into the live session map, drops the
+        default empty tab, and activates the most recent restored session.
+        """
+        results: list[tuple[str, SessionState]] = []
+        for session in sessions:
+            if not session.messages:
+                continue
+            tab_id = uuid.uuid4().hex[:8]
+            self._sessions[tab_id] = session
+            results.append((tab_id, session))
+            log_debug(f"Restored session {session.id} as tab {tab_id}")
         if results:
-            # Remove the default empty session that was created in __init__
-            # and set the first restored tab as active
+            # Drop the default empty session created in __init__ and activate
+            # the most recent restored tab. If the user already started working
+            # in the default tab during the (async) load, keep them there.
+            default_dropped = False
             if self._active_tab_id in self._sessions:
                 default_session = self._sessions[self._active_tab_id]
                 if not default_session.messages:
                     del self._sessions[self._active_tab_id]
-            self._active_tab_id = results[-1][0]  # most recent
+                    default_dropped = True
+            if default_dropped:
+                self._active_tab_id = results[-1][0]  # most recent
         return results
+
+    def restore_sessions(self) -> list[tuple[str, SessionState]]:
+        """Load ALL saved sessions and register them as tabs (synchronous).
+
+        Retained for callers/tests that want the blocking path; the panel uses
+        the split ``load_restorable_sessions`` + ``register_restored_sessions``
+        so the disk/parse cost stays off the UI thread.
+        """
+        return self.register_restored_sessions(self.load_restorable_sessions())
 
     def restore_session(self) -> SessionState | None:
         """Legacy: restore only the latest session into the active tab."""

--- a/tests/providers/test_provider_adapters.py
+++ b/tests/providers/test_provider_adapters.py
@@ -8,6 +8,7 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from tests.mocks.ida_mock import install_ida_mocks
+
 install_ida_mocks()
 
 
@@ -23,6 +24,7 @@ class TestBuiltinModels(unittest.TestCase):
     def test_anthropic_builtin_models(self):
         _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
+
         p = AnthropicProvider(api_key="test", model="test")
         models = p._builtin_models()
         self.assertTrue(len(models) > 0)
@@ -32,21 +34,29 @@ class TestBuiltinModels(unittest.TestCase):
 
     def test_openai_builtin_models(self):
         from rikugan.providers.openai_provider import OpenAIProvider
+
         p = OpenAIProvider(api_key="test", model="test")
         models = p._builtin_models()
         self.assertTrue(len(models) > 0)
         for m in models:
             self.assertEqual(m.provider, "openai")
 
-    def test_codex_builtin_models(self):
+    def test_codex_has_no_offline_defaults(self):
+        # Codex intentionally has no builtin/fallback list: the model list is
+        # always resolved live (list_models -> _fetch_models_live) so a failed
+        # fetch surfaces as an error instead of placeholder models.
         from rikugan.providers.codex_provider import CodexProvider
-        models = CodexProvider._builtin_models()
-        self.assertTrue(len(models) > 0)
-        for m in models:
-            self.assertEqual(m.provider, "codex")
+
+        self.assertEqual(CodexProvider._builtin_models(), [])
+        # Codex overrides list_models so the base builtin-fallback path is bypassed.
+        self.assertIsNot(
+            CodexProvider.list_models,
+            CodexProvider.__mro__[1].list_models,  # base LLMProvider.list_models
+        )
 
     def test_gemini_builtin_models(self):
         from rikugan.providers.gemini_provider import GeminiProvider
+
         models = GeminiProvider._builtin_models()
         self.assertTrue(len(models) > 0)
         for m in models:
@@ -60,6 +70,7 @@ class TestProviderCapabilities(unittest.TestCase):
     def test_anthropic_capabilities(self):
         _reload_anthropic_provider_module()
         from rikugan.providers.anthropic_provider import AnthropicProvider
+
         p = AnthropicProvider(api_key="test", model="test")
         caps = p.capabilities
         self.assertTrue(caps.streaming)
@@ -68,6 +79,7 @@ class TestProviderCapabilities(unittest.TestCase):
 
     def test_openai_capabilities(self):
         from rikugan.providers.openai_provider import OpenAIProvider
+
         p = OpenAIProvider(api_key="test", model="test")
         caps = p.capabilities
         self.assertTrue(caps.streaming)
@@ -75,6 +87,7 @@ class TestProviderCapabilities(unittest.TestCase):
 
     def test_gemini_capabilities(self):
         from rikugan.providers.gemini_provider import GeminiProvider
+
         p = GeminiProvider(api_key="test", model="test")
         caps = p.capabilities
         self.assertTrue(caps.streaming)

--- a/tests/tools/test_panel_core.py
+++ b/tests/tools/test_panel_core.py
@@ -319,6 +319,8 @@ def _make_panel():
     panel._mutation_panel = None
     panel._skills_refresh_timer = None
     panel._poll_timer = None
+    panel._restore_timer = None
+    panel._restore_queue = None
     panel._input_area = MagicMock()
     panel._send_btn = MagicMock()
     panel._cancel_btn = MagicMock()


### PR DESCRIPTION
Codex / Windows correctness:
- Read Codex auth.json and models_cache.json as UTF-8. On Windows the default cp1252 decode crashed on the real Codex CLI cache, so a pre-configured Codex silently fell back to placeholder models.
- Codex now always resolves models from upstream (no builtin fallback); a failed fetch surfaces as an error instead of stale defaults.
- Apply the same UTF-8 fix to session history and config reads, which otherwise broke session restore on any chat with non-ASCII content.

Loading / streaming smoothness:
- Move session restore disk I/O + parse off the UI thread so the panel paints immediately; tabs build back on the UI thread when ready.
- Cache the markdown theme per widget instead of re-resolving the host palette and re-blending colors every render frame.
- Committed/tail split with two labels: finalized markdown blocks render once and are never re-laid-out; only the live tail re-renders per frame.
- Typewriter display buffer: deltas reveal at a steady ~33fps cadence with catch-up, so bursty network arrival no longer jumps.
- Thinking-block regex split only runs when a <think> tag is present.

Scroll behavior:
- Sending/queuing a message force-scrolls to the bottom.
- Explicit "follow" intent toggled by the user's own scrolling: while an agent streams, scrolling up to read history is no longer overridden.

Tooling:
- Add ci-local.ps1, a Windows PowerShell mirror of ci-local.sh.