### PR TITLE
fix(providers): resolve auth cache relative to its package (#62)

### DIFF
--- a/rikugan/providers/auth_compat.py
+++ b/rikugan/providers/auth_compat.py
@@ -10,9 +10,15 @@ from ..core.logging import log_debug, log_warning
 
 
 def _load_auth_cache() -> ModuleType | None:
+    # Resolve relative to this package, not by absolute name.  Binary Ninja loads
+    # the plugin directory itself as top-level ``rikugan``, so the real package
+    # there is ``rikugan.rikugan.providers`` and an absolute
+    # ``rikugan.providers.auth_cache`` import raises ModuleNotFoundError.
+    # TypeError guards the degenerate case of an empty ``__package__``, which
+    # import_module reports as TypeError rather than ImportError.
     try:
-        return importlib.import_module("rikugan.providers.auth_cache")
-    except ImportError as e:
+        return importlib.import_module(".auth_cache", __package__)
+    except (ImportError, TypeError) as e:
         log_warning(f"Unable to import auth cache: {e}")
         return None
 
@@ -32,7 +38,7 @@ def _call_module_func(module: ModuleType, name: str, *args: Any) -> bool:
     func = getattr(module, name, None)
     if not callable(func):
         log_warning(
-            f"rikugan.providers.auth_cache is missing {name} "
+            f"{module.__name__} is missing {name} "
             f"from {_module_origin(module)}; installation may be stale or mixed. "
             "Restart the host and rerun the Rikugan installer after updating.",
         )

--- a/tests/providers/test_auth_compat.py
+++ b/tests/providers/test_auth_compat.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
+import textwrap
 import types
+from pathlib import Path
 
+import pytest
+
+import rikugan.providers.auth_compat as auth_compat
 from rikugan.providers.auth_compat import apply_keychain_consent, invalidate_auth_cache
 
 
@@ -32,3 +38,46 @@ def test_apply_keychain_consent_handles_stale_auth_cache(monkeypatch):
     monkeypatch.setitem(sys.modules, "rikugan.providers.auth_cache", module)
 
     assert apply_keychain_consent(False) is False
+
+
+# Binary Ninja imports the plugin DIRECTORY as top-level ``rikugan``, so the real
+# package is ``rikugan.rikugan.providers`` and the absolute name
+# ``rikugan.providers.auth_cache`` does not exist. Run in a subprocess so the
+# duplicate package tree never pollutes this session's sys.modules.
+_NESTED_LAYOUT_PROBE = """
+import importlib, sys
+sys.path.insert(0, {host!r})
+importlib.import_module("rikugan")
+try:
+    importlib.import_module("rikugan.providers.auth_cache")
+    print("ABSOLUTE_RESOLVES")
+except ImportError:
+    print("ABSOLUTE_FAILS")
+compat = importlib.import_module("rikugan.rikugan.providers.auth_compat")
+cache = importlib.import_module("rikugan.rikugan.providers.auth_cache")
+print("APPLIED", compat.apply_keychain_consent(True))
+print("CONSENT", cache._keychain_consent)
+print("SAME_MODULE", compat._load_auth_cache() is cache)
+"""
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="requires symlink support")
+def test_consent_applies_under_nested_plugin_layout(tmp_path):
+    """Regression: consent must reach auth_cache when the package is nested."""
+    repo_root = Path(auth_compat.__file__).resolve().parents[2]
+    host = tmp_path / "plugins"
+    host.mkdir()
+    (host / "rikugan").symlink_to(repo_root, target_is_directory=True)
+
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(_NESTED_LAYOUT_PROBE).format(host=str(host))],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout.split()
+    assert "ABSOLUTE_FAILS" in out, "layout no longer reproduces the nesting under test"
+    assert "APPLIED True" in result.stdout
+    assert "CONSENT True" in result.stdout
+    assert "SAME_MODULE True" in result.stdout


### PR DESCRIPTION
With the anthropic provider and the keychain checkbox enabled, Rikugan reports "No Anthropic credential found" on Binary Ninja even when the token is valid and `oauth_consent_accepted` is true. The log says why:

```
Unable to import auth cache: No module named 'rikugan.providers'
```

Binary Ninja loads the plugin directory itself as top-level `rikugan`, so the real package is `rikugan.rikugan.providers`. `auth_compat._load_auth_cache()` imported by the absolute name `rikugan.providers.auth_cache`, which cannot exist there. It failed on every call, `apply_keychain_consent()` returned False, `_keychain_consent` stayed False, and the keychain lookup was skipped. Closes #62.

What changed:
- Import relative to the package so both layouts resolve. IDA is unaffected, since `install_ida.sh` puts `rikugan/` in as a real top-level package and the resolved name stays `rikugan.providers.auth_cache`.
- Catch TypeError as well as ImportError. That is what `import_module` raises for a relative import with an empty `__package__`, and it would previously escape the handler.
- Report the module's real name in the stale-install warning, instead of a hardcoded one that does not exist on Binary Ninja.

The new test builds the nested layout in a subprocess and asserts consent reaches the same `auth_cache` module object the providers read. It fails against the old code with `APPLIED False` / `CONSENT False`, so it pins the regression rather than just covering the line.

`rikugan_plugin.py` keeps its absolute imports on purpose. IDA loads it as a top-level script with no package, so relative imports are not available there.

One thing worth your call: `auth_compat` exists to tolerate a stale auth cache, but `settings_dialog.py` and `panel_core.py` already import `auth_cache` directly at module scope, so a partially-updated install would fail at import time before the shim could help. Collapsing it to a plain relative import would remove this class of bug entirely. I kept the change minimal here rather than deleting a module you added deliberately.