### PR TITLE
fix(providers): use a working CA bundle for urllib requests (#63)

### DIFF
--- a/rikugan/core/tls.py
+++ b/rikugan/core/tls.py
@@ -1,0 +1,136 @@
+"""Shared TLS trust store for ``urllib``-based provider requests.
+
+Embedded interpreters do not always ship a usable CA bundle.  Binary Ninja's
+bundled ``bnpython3``, for example, is a repackaged python.org build whose
+OpenSSL is compiled with ``OPENSSLDIR`` pointing at
+``/Library/Frameworks/Python.framework/Versions/3.10/etc/openssl`` — a path
+that does not exist unless the user separately installed python.org Python.
+``ssl.create_default_context()`` then loads zero CA certificates and every
+HTTPS request dies with::
+
+    [SSL: CERTIFICATE_VERIFY_FAILED] unable to get local issuer certificate
+
+Providers that go through ``httpx`` (the OpenAI/Anthropic SDKs) are unaffected
+because ``httpx`` defaults to the ``certifi`` bundle.  The ``urllib`` call sites
+have no such default, so they use :func:`ssl_context` instead.
+
+Resolution order:
+
+1. If ``SSL_CERT_FILE`` or ``SSL_CERT_DIR`` is set, that is the operator's
+   explicit trust policy — it is used as-is and never supplemented, even when
+   it resolves to nothing.  Substituting a broader store behind an operator who
+   pinned a narrow one would silently widen trust.
+2. The interpreter's own default trust store, when it actually has CAs.
+3. The ``certifi`` bundle, if importable.
+4. A platform CA bundle from :data:`_FALLBACK_BUNDLES`.
+
+Verification is never disabled.  If no bundle is found the default context is
+returned unchanged so the request fails loudly rather than silently trusting
+an unverified peer.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import ssl
+
+from .logging import log_debug, log_warning
+
+# Environment variables OpenSSL consults for an operator-chosen trust store.
+_TRUST_ENV_VARS = ("SSL_CERT_FILE", "SSL_CERT_DIR")
+
+# Platform CA bundles, checked in order when the interpreter has none of its own.
+# macOS ships the first (``/etc`` is a symlink to ``/private/etc``, so listing
+# both would be the same inode); the rest cover common Linux distributions.
+_FALLBACK_BUNDLES = (
+    "/etc/ssl/cert.pem",
+    "/etc/ssl/certs/ca-certificates.crt",
+    "/etc/pki/tls/certs/ca-bundle.crt",
+)
+
+
+def _operator_trust_store_configured() -> bool:
+    """Report whether the environment pins an explicit trust store.
+
+    Returns:
+        ``True`` if ``SSL_CERT_FILE`` or ``SSL_CERT_DIR`` is set to a non-empty
+        value, meaning the caller has chosen a trust store deliberately.
+    """
+    return any(os.environ.get(name, "").strip() for name in _TRUST_ENV_VARS)
+
+
+def _certifi_bundle() -> str | None:
+    """Return the path to the ``certifi`` CA bundle, or ``None`` if unusable.
+
+    Returns:
+        Absolute path to ``cacert.pem``, or ``None`` when ``certifi`` is not
+        installed or its bundle is missing from disk.
+    """
+    try:
+        import certifi
+    except ImportError:
+        return None
+    path = certifi.where()
+    return path if path and os.path.exists(path) else None
+
+
+def _candidate_bundles() -> tuple[str, ...]:
+    """Return CA bundle paths to try, most preferred first.
+
+    Returns:
+        Existing bundle paths; may be empty if the host has no usable store.
+    """
+    certifi_path = _certifi_bundle()
+    paths = (certifi_path, *_FALLBACK_BUNDLES) if certifi_path else _FALLBACK_BUNDLES
+    return tuple(p for p in paths if os.path.exists(p))
+
+
+def _has_ca_certs(context: ssl.SSLContext) -> bool:
+    """Report whether a context has any trusted CA certificates loaded.
+
+    Args:
+        context: The context to inspect.
+
+    Returns:
+        ``True`` if at least one CA certificate is in the trust store.
+    """
+    try:
+        return context.cert_store_stats().get("x509_ca", 0) > 0
+    except (AttributeError, OSError):  # pragma: no cover - non-OpenSSL backends
+        return False
+
+
+@functools.lru_cache(maxsize=1)
+def ssl_context() -> ssl.SSLContext:
+    """Return a verifying :class:`ssl.SSLContext` with a working trust store.
+
+    The result is cached for the life of the process; restart the host
+    application to pick up a newly installed CA bundle.
+
+    Returns:
+        A context with hostname checking and certificate verification enabled.
+    """
+    context = ssl.create_default_context()
+    if _operator_trust_store_configured():
+        log_debug(f"TLS: using trust store pinned by {'/'.join(_TRUST_ENV_VARS)}")
+        return context
+    if _has_ca_certs(context):
+        return context
+
+    for path in _candidate_bundles():
+        try:
+            context.load_verify_locations(cafile=path)
+        except (OSError, ssl.SSLError) as exc:
+            log_debug(f"TLS: CA bundle {path} unusable: {exc}")
+            continue
+        if _has_ca_certs(context):
+            log_debug(f"TLS: loaded CA bundle from {path}")
+            return context
+
+    log_warning(
+        "TLS: no CA bundle found for this interpreter; HTTPS requests will fail "
+        "certificate verification. Set SSL_CERT_FILE to a PEM bundle "
+        "(e.g. /etc/ssl/cert.pem) or install certifi."
+    )
+    return context

--- a/rikugan/providers/codex_provider.py
+++ b/rikugan/providers/codex_provider.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, NoReturn
 
 from ..core.errors import AuthenticationError, ContextLengthError, ProviderError, RateLimitError
+from ..core.tls import ssl_context
 from ..core.types import Message, ModelInfo, ProviderCapabilities, Role, StreamChunk, TokenUsage, ToolCall
 from .base import LLMProvider
 
@@ -117,7 +118,7 @@ def _request_json(
     if headers:
         req_headers.update(headers)
     req = urllib.request.Request(url, data=data, headers=req_headers, method="GET" if data is None else "POST")
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
+    with urllib.request.urlopen(req, timeout=timeout, context=ssl_context()) as resp:
         raw = resp.read().decode("utf-8")
     return json.loads(raw) if raw else {}
 
@@ -130,7 +131,7 @@ def _request_form(url: str, fields: dict[str, str], timeout: float = 120.0) -> d
         headers={"Content-Type": "application/x-www-form-urlencoded", "User-Agent": "Rikugan Codex"},
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=timeout) as resp:
+    with urllib.request.urlopen(req, timeout=timeout, context=ssl_context()) as resp:
         return json.loads(resp.read().decode("utf-8"))
 
 
@@ -490,7 +491,7 @@ class CodexProvider(LLMProvider):
             headers["Content-Type"] = "application/json"
         req = urllib.request.Request(url, data=data, headers=headers, method=method)
         try:
-            resp = urllib.request.urlopen(req, timeout=120.0)
+            resp = urllib.request.urlopen(req, timeout=120.0, context=ssl_context())
         except urllib.error.HTTPError as exc:
             if exc.code == 401:
                 self._refresh_auth()
@@ -498,7 +499,7 @@ class CodexProvider(LLMProvider):
                 if payload is not None:
                     headers["Content-Type"] = "application/json"
                 req = urllib.request.Request(url, data=data, headers=headers, method=method)
-                resp = urllib.request.urlopen(req, timeout=120.0)
+                resp = urllib.request.urlopen(req, timeout=120.0, context=ssl_context())
             else:
                 raise
         if stream:

--- a/rikugan/providers/ollama_provider.py
+++ b/rikugan/providers/ollama_provider.py
@@ -7,6 +7,7 @@ import os
 import urllib.request
 
 from ..core.logging import log_debug
+from ..core.tls import ssl_context
 from ..core.types import ModelInfo, ProviderCapabilities
 from .openai_compat import OpenAICompatProvider
 
@@ -55,7 +56,10 @@ class OllamaProvider(OpenAICompatProvider):
         try:
             base = self.api_base.removesuffix("/v1").rstrip("/")
             url = f"{base}/api/tags"
-            with urllib.request.urlopen(url, timeout=5) as resp:
+            # Only override the opener for TLS. Passing a context on plain http
+            # would bypass any opener the host installed and buy nothing.
+            context = ssl_context() if url.lower().startswith("https:") else None
+            with urllib.request.urlopen(url, timeout=5, context=context) as resp:
                 data = json.loads(resp.read())
             models = []
             for m in data.get("models", []):

--- a/tests/core/test_tls.py
+++ b/tests/core/test_tls.py
@@ -1,0 +1,167 @@
+"""Tests for rikugan.core.tls — CA bundle resolution for urllib call sites."""
+
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+
+import pytest
+
+from rikugan.core import tls
+
+
+def _real_bundle() -> Path | None:
+    """Return an existing platform CA bundle, or None on hosts without one."""
+    return next((Path(p) for p in tls._FALLBACK_BUNDLES if Path(p).exists()), None)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_context(monkeypatch):
+    """Drop the memoized context and any inherited trust-store environment."""
+    for name in tls._TRUST_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    tls.ssl_context.cache_clear()
+    yield
+    tls.ssl_context.cache_clear()
+
+
+class TestOperatorTrustStore:
+    """An explicitly configured trust store is policy, not a starting point."""
+
+    @pytest.mark.parametrize("var", tls._TRUST_ENV_VARS)
+    def test_configured_store_is_never_supplemented(self, monkeypatch, var):
+        """A pinned bundle resolving to nothing must NOT gain the public roots."""
+        monkeypatch.setenv(var, "/nonexistent/pinned.pem")
+        assert tls._operator_trust_store_configured() is True
+        untouched = ssl.create_default_context().cert_store_stats()["x509_ca"]
+
+        context = tls.ssl_context()
+        assert context.cert_store_stats()["x509_ca"] == untouched
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_unset_environment_is_not_configured(self):
+        assert tls._operator_trust_store_configured() is False
+
+    def test_whitespace_value_is_not_configured(self, monkeypatch):
+        monkeypatch.setenv("SSL_CERT_FILE", "   ")
+        assert tls._operator_trust_store_configured() is False
+
+
+class TestCandidateBundles:
+    """Bundle discovery must only ever return paths that exist."""
+
+    def test_only_existing_paths_returned(self, monkeypatch, tmp_path):
+        present = tmp_path / "present.pem"
+        present.write_text("", encoding="utf-8")
+        monkeypatch.setattr(tls, "_FALLBACK_BUNDLES", (str(present), str(tmp_path / "gone.pem")))
+
+        result = tls._candidate_bundles()
+        assert str(present) in result
+        assert str(tmp_path / "gone.pem") not in result
+        assert all(Path(p).exists() for p in result)
+
+    def test_certifi_takes_priority(self, monkeypatch, tmp_path):
+        certifi_path = tmp_path / "cacert.pem"
+        fallback = tmp_path / "cert.pem"
+        for p in (certifi_path, fallback):
+            p.write_text("", encoding="utf-8")
+        monkeypatch.setattr(tls, "_certifi_bundle", lambda: str(certifi_path))
+        monkeypatch.setattr(tls, "_FALLBACK_BUNDLES", (str(fallback),))
+
+        result = tls._candidate_bundles()
+        assert result == (str(certifi_path), str(fallback))
+        assert len(result) == 2
+
+    def test_missing_certifi_is_not_fatal(self, monkeypatch):
+        monkeypatch.setattr(tls, "_certifi_bundle", lambda: None)
+        monkeypatch.setattr(tls, "_FALLBACK_BUNDLES", ())
+
+        result = tls._candidate_bundles()
+        assert result == ()
+        assert isinstance(result, tuple)
+
+    def test_configured_fallbacks_are_absolute_and_unique(self):
+        """/etc symlinks to /private/etc on macOS; listing both is dead weight."""
+        assert len(set(tls._FALLBACK_BUNDLES)) == len(tls._FALLBACK_BUNDLES)
+        assert all(p.startswith("/") for p in tls._FALLBACK_BUNDLES)
+        assert len(tls._FALLBACK_BUNDLES) >= 1
+
+
+class TestSSLContext:
+    """The returned context must always verify, bundle found or not."""
+
+    def test_uses_interpreter_default_when_it_has_certs(self, monkeypatch):
+        """A healthy interpreter should not trigger any bundle loading."""
+        monkeypatch.setattr(
+            tls,
+            "_candidate_bundles",
+            lambda: pytest.fail("bundle lookup should be skipped when defaults work"),
+        )
+        monkeypatch.setattr(tls, "_has_ca_certs", lambda ctx: True)
+
+        context = tls.ssl_context()
+        assert isinstance(context, ssl.SSLContext)
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_loads_real_bundle_when_defaults_empty(self, monkeypatch, tmp_path):
+        """The bnpython3 case: an empty default store repaired by a real PEM.
+
+        Uses the real loader and the real predicate — nothing about the
+        mechanism under test is mocked.
+        """
+        source = _real_bundle()
+        if source is None:  # pragma: no cover - host without a CA bundle
+            pytest.skip("no platform CA bundle available")
+        bundle = tmp_path / "cert.pem"
+        bundle.write_bytes(source.read_bytes())
+
+        # A context with no CAs at all, standing in for bnpython3's broken default.
+        empty = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        empty.verify_mode = ssl.CERT_REQUIRED
+        assert tls._has_ca_certs(empty) is False
+        monkeypatch.setattr(ssl, "create_default_context", lambda *a, **k: empty)
+        monkeypatch.setattr(tls, "_candidate_bundles", lambda: (str(bundle),))
+
+        context = tls.ssl_context()
+        assert tls._has_ca_certs(context) is True
+        assert context.cert_store_stats()["x509_ca"] > 0
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_skips_unusable_bundles(self, monkeypatch, tmp_path):
+        """An unreadable bundle must not stop the search."""
+        bad, good = tmp_path / "bad.pem", tmp_path / "good.pem"
+        bad.write_text("not a certificate", encoding="utf-8")
+        source = _real_bundle()
+        if source is None:  # pragma: no cover - host without a CA bundle
+            pytest.skip("no platform CA bundle available")
+        good.write_bytes(source.read_bytes())
+
+        empty = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        empty.verify_mode = ssl.CERT_REQUIRED
+        monkeypatch.setattr(ssl, "create_default_context", lambda *a, **k: empty)
+        monkeypatch.setattr(tls, "_candidate_bundles", lambda: (str(bad), str(good)))
+
+        context = tls.ssl_context()
+        assert tls._has_ca_certs(context) is True
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+
+    def test_verification_stays_on_with_no_bundle(self, monkeypatch):
+        """No trust store is a loud failure, never a silent downgrade."""
+        monkeypatch.setattr(tls, "_candidate_bundles", lambda: ())
+        monkeypatch.setattr(tls, "_has_ca_certs", lambda ctx: False)
+
+        context = tls.ssl_context()
+        assert context.verify_mode == ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+        assert isinstance(context, ssl.SSLContext)
+
+    def test_result_is_memoized(self, monkeypatch):
+        monkeypatch.setattr(tls, "_has_ca_certs", lambda ctx: True)
+
+        first = tls.ssl_context()
+        assert tls.ssl_context() is first
+        assert tls.ssl_context.cache_info().currsize == 1

--- a/tests/providers/test_ollama_openai_compat.py
+++ b/tests/providers/test_ollama_openai_compat.py
@@ -81,7 +81,7 @@ class TestOllamaListModels(unittest.TestCase):
         payload = {"models": [{"name": "phi3"}]}
         mock_resp = self._make_mock_response(payload)
         captured = {}
-        def fake_urlopen(url, timeout=None):
+        def fake_urlopen(url, timeout=None, context=None):
             captured["url"] = url
             return mock_resp
         with patch("urllib.request.urlopen", fake_urlopen):


### PR DESCRIPTION
Setup Codex cannot complete on Binary Ninja, it fails with `CERTIFICATE_VERIFY_FAILED`. The bundled `bnpython3` is a repackaged python.org build, and its OpenSSL is compiled with

```
OPENSSLDIR: "/Library/Frameworks/Python.framework/Versions/3.10/etc/openssl"
```

which does not exist unless python.org Python is installed separately. `ssl.create_default_context()` loads zero CA certificates, so every `urllib` HTTPS request fails:

```
$ bnpython3 probe.py
cafile: /Library/Frameworks/Python.framework/Versions/3.10/etc/openssl/cert.pem False
TLS FAIL: [SSL: CERTIFICATE_VERIFY_FAILED] ...

$ SSL_CERT_FILE=/etc/ssl/cert.pem bnpython3 probe.py
TLS OK
```

Providers on the OpenAI/Anthropic SDKs were never affected, httpx defaults to certifi. Only the `urllib` sites are. Closes #63.

Adds `core/tls.py` with one cached context, resolved in this order:

- An explicitly set `SSL_CERT_FILE` or `SSL_CERT_DIR` is used as-is and never supplemented. If someone pins a narrow corporate bundle and the path is wrong, they get a failure rather than the public root set silently substituted underneath them.
- The interpreter's own store, when it actually has CAs.
- The certifi bundle, imported opportunistically so it stays a preference and not a new dependency.
- A platform bundle such as `/etc/ssl/cert.pem`.

Verification is never disabled. Every path returns a context with `check_hostname` and `CERT_REQUIRED` intact, and when nothing is found the default context is returned unchanged so the request fails loudly instead of trusting an unverified peer.

Call sites:
- All four `urlopen` calls in `codex_provider`, including the retry after a 401 refresh. Fixing only the first would have left every token refresh broken.
- `ollama_provider` passes a context only for https. On plain http a context bypasses any opener the host installed and buys nothing, and the default base URL is `http://localhost:11434`.

The tests use a real PEM and the real loader for the repair path, so they assert the trust store actually gains CAs rather than that a mock was called.