### PR TITLE
fix(codex): report the newest known client version when listing models (#64)

### DIFF
--- a/rikugan/providers/codex_provider.py
+++ b/rikugan/providers/codex_provider.py
@@ -24,7 +24,7 @@ CODEX_ISSUER = "https://auth.openai.com"
 CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 CODEX_AUTH_MODE = "chatgpt"
 CODEX_ORIGINATOR = "codex_cli_rs"
-CODEX_MODELS_CLIENT_VERSION = "0.133.0"
+CODEX_MODELS_CLIENT_VERSION = "0.146.0"
 
 
 @dataclass
@@ -95,15 +95,47 @@ def _id_token_info(id_token: str) -> dict[str, Any]:
     }
 
 
+def _version_tuple(value: str) -> tuple[int, ...]:
+    """Parse a dotted version into comparable integers.
+
+    Parsing stops at the first segment that is not purely numeric, so a
+    prerelease such as ``"0.146.0-beta.1"`` compares equal to ``"0.146.0"``
+    instead of ranking above it.
+
+    Args:
+        value: A version string such as ``"0.146.0"``.
+
+    Returns:
+        One integer per leading numeric segment; empty if there are none.
+    """
+    parts: list[int] = []
+    for chunk in value.lstrip("vV").split("."):
+        if not chunk.isdigit():
+            break
+        parts.append(int(chunk))
+    return tuple(parts)
+
+
 def _codex_models_client_version() -> str:
+    """Return the newest Codex client version discoverable on this machine.
+
+    The models endpoint gates availability on this value, so reporting a stale
+    version silently hides newer models.  ``models_cache.json`` records the
+    version that last wrote the cache, which can lag far behind the installed
+    CLI, so take the highest of every candidate rather than the first found.
+
+    Returns:
+        A dotted version string, never empty.
+    """
+    candidates = [CODEX_MODELS_CLIENT_VERSION]
     for path, key in ((_models_cache_path(), "client_version"), (_version_path(), "latest_version")):
         try:
             value = json.loads(path.read_text(encoding="utf-8")).get(key)
         except (OSError, UnicodeDecodeError, json.JSONDecodeError, AttributeError):
             continue
         if isinstance(value, str) and value:
-            return value
-    return CODEX_MODELS_CLIENT_VERSION
+            candidates.append(value)
+    return max(candidates, key=_version_tuple)
 
 
 def _request_json(

--- a/tests/providers/test_codex_provider.py
+++ b/tests/providers/test_codex_provider.py
@@ -12,7 +12,14 @@ from unittest.mock import patch
 
 from rikugan.core.errors import AuthenticationError
 from rikugan.core.types import Message, Role
-from rikugan.providers.codex_provider import CodexProvider, _id_token_info, codex_auth_status
+from rikugan.providers.codex_provider import (
+    CODEX_MODELS_CLIENT_VERSION,
+    CodexProvider,
+    _codex_models_client_version,
+    _id_token_info,
+    _version_tuple,
+    codex_auth_status,
+)
 
 
 def _jwt(claims: dict) -> str:
@@ -115,7 +122,7 @@ class TestCodexModels(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp, patch.dict(os.environ, {"CODEX_HOME": tmp}, clear=False):
             home = Path(tmp)
             _write_auth(home, {"access_token": "access", "refresh_token": "refresh", "account_id": "acct"})
-            (home / "models_cache.json").write_text(json.dumps({"client_version": "0.133.0"}))
+            (home / "models_cache.json").write_text(json.dumps({"client_version": "0.150.0"}))
             provider = CodexProvider()
 
             with patch.object(
@@ -146,7 +153,66 @@ class TestCodexModels(unittest.TestCase):
         self.assertEqual(models[0].context_window, 272000)
         self.assertTrue(models[0].supports_tools)
         self.assertTrue(models[0].supports_vision)
-        request.assert_called_once_with("GET", "models?client_version=0.133.0", None, stream=False)
+        request.assert_called_once_with("GET", "models?client_version=0.150.0", None, stream=False)
+
+
+class TestCodexClientVersion(unittest.TestCase):
+    """The models endpoint gates availability on client_version — never report a stale one."""
+
+    def _resolve(self, files: dict[str, dict]) -> str:
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(os.environ, {"CODEX_HOME": tmp}, clear=False):
+            for name, payload in files.items():
+                (Path(tmp) / name).write_text(json.dumps(payload))
+            return _codex_models_client_version()
+
+    def test_stale_models_cache_does_not_mask_newer_version(self):
+        """The real-world case: an old cache alongside an updated CLI."""
+        resolved = self._resolve(
+            {
+                "models_cache.json": {"client_version": "0.134.0"},
+                "version.json": {"latest_version": "0.146.0"},
+            }
+        )
+        self.assertEqual(resolved, "0.146.0")
+
+    def test_newer_cache_wins_over_version_file(self):
+        resolved = self._resolve(
+            {
+                "models_cache.json": {"client_version": "0.152.0"},
+                "version.json": {"latest_version": "0.146.0"},
+            }
+        )
+        self.assertEqual(resolved, "0.152.0")
+
+    def test_builtin_floor_used_when_local_versions_are_older(self):
+        resolved = self._resolve({"models_cache.json": {"client_version": "0.100.0"}})
+        self.assertEqual(resolved, CODEX_MODELS_CLIENT_VERSION)
+
+    def test_missing_files_fall_back_to_builtin(self):
+        self.assertEqual(self._resolve({}), CODEX_MODELS_CLIENT_VERSION)
+
+    def test_malformed_json_is_ignored(self):
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(os.environ, {"CODEX_HOME": tmp}, clear=False):
+            (Path(tmp) / "models_cache.json").write_text("{not json")
+            self.assertEqual(_codex_models_client_version(), CODEX_MODELS_CLIENT_VERSION)
+
+    def test_numeric_not_lexicographic_ordering(self):
+        """String comparison would rank "0.9.0" above "0.146.0"."""
+        self.assertEqual(max(["0.9.0", "0.146.0"], key=_version_tuple), "0.146.0")
+
+    def test_prerelease_does_not_outrank_its_release(self):
+        """A -beta/rc suffix must never resolve higher than the plain release."""
+        for prerelease in ("0.146.0-beta.1", "0.146.0rc1", "0.146.0+build.7"):
+            with self.subTest(prerelease=prerelease):
+                self.assertLessEqual(_version_tuple(prerelease), _version_tuple("0.146.0"))
+
+    def test_leading_v_is_tolerated(self):
+        self.assertEqual(_version_tuple("v0.146.0"), _version_tuple("0.146.0"))
+
+    def test_unparsable_versions_never_win(self):
+        for junk in ("", "unknown", "not.a.version"):
+            with self.subTest(junk=junk):
+                self.assertLess(_version_tuple(junk), _version_tuple("0.1.0"))
 
 
 class TestCodexRequestPayload(unittest.TestCase):


### PR DESCRIPTION
The codex model picker only offers GPT-5.5, GPT-5.4 and GPT-5.4-Mini. The models endpoint gates what it returns on the `client_version` query parameter, and `_codex_models_client_version()` returned the first value it found, checking `models_cache.json` before `version.json`. That cache records whichever CLI last wrote it, so a months-old cache pins the request long after the CLI has been updated:

```
models_cache.json  client_version 0.134.0   (stale)
version.json       latest_version 0.146.0
codex --version                   0.146.0
```

Asking the endpoint with each value returns a different list:

```
0.134.0 -> gpt-5.5, gpt-5.4, gpt-5.4-mini
0.146.0 -> gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-mini
```

So the newer models were hidden by a stale local file, not by the account. Closes #64.

What changed:
- Take the highest candidate instead of the first. These are lower bounds on what the machine can speak, so max is the right reduction and it self-heals when the CLI updates.
- Compare numerically. String comparison ranks `0.9.0` above `0.146.0`. Parsing stops at the first non-numeric segment so `0.146.0-beta.1` does not outrank `0.146.0`.
- Raise the built-in floor from 0.133.0, which predates these models. That value is only reached when there is no Codex CLI at all, and it was leaving those users on a pre-gpt-5.6 list.

Nothing else needs to change to use the models. Sending the existing `_build_request_kwargs` payload for `gpt-5.6-sol` and `gpt-5.6-terra` returns HTTP 200 and streams the same event types `_normalize_response` already handles, and `_parse_model_info` has no model allowlist.

Worth flagging for your judgement: `version.json` holds the latest *available* release, which is not strictly the installed one, so on a machine that has never run an update this can claim a version slightly ahead of what is installed. I preferred it to the alternatives because undershooting fails silently, the model simply never appears, while overshooting fails loudly at request time. Reading `codex --version` would be exact but spawns a process on a UI path and needs the binary on PATH, which is often not the case for GUI-launched apps on macOS.